### PR TITLE
animationIterationCount infinite option

### DIFF
--- a/src/Css.re
+++ b/src/Css.re
@@ -707,7 +707,18 @@ let animationFillMode = (v) =>
     }
   );
 
-let animationIterationCount = intProp("animationIterationCount");
+type animationIterationCount =
+  | Infinite
+  | Iterate(int);
+
+let animationIterationCount = (v) =>
+  Property(
+    "animationIterationCount",
+    switch v {
+      | Infinite => "infinite"
+      | Iterate(v) => string_of_int(v)
+    }
+  );
 
 type animationPlayState =
   | Paused

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -407,7 +407,11 @@ type animationFillMode =
 
 let animationFillMode: animationFillMode => rule;
 
-let animationIterationCount: int => rule;
+type animationIterationCount =
+  | Infinite
+  | Iterate(int);
+
+let animationIterationCount: animationIterationCount => rule;
 
 let animationName: keyframes => rule;
 


### PR DESCRIPTION
Added `Infinite` as an option to `animationIterationCount`.

I needed this option to allow for infinite looping of an animation I was working on.

If you want me to implement this in some other way just let me know! 😃 

If this isn't wanted feel free to close this pull request.