### PR TITLE
Change the repo URL in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/poeschko/bs-glamor.git"
+    "url": "git+https://github.com/SentiaAnalytics/bs-css.git"
   },
   "dependencies": {
     "glamor": "^2.0.0"


### PR DESCRIPTION
This really make me confused for a while when researching a css solution in ReasonML since both package is pointed at the same github project. Please merge this and cut a release after that. I'd would be happy to adjust others information as you see fit 