### PR TITLE
Added cssunit auto. Added selectors for before and after.

### DIFF
--- a/src/Css.re
+++ b/src/Css.re
@@ -104,6 +104,8 @@ let vw = (i) => {j|$(i)vw|j};
 
 let zero = "0";
 
+let auto = "auto";
+
 
 /*********
  * ANGLE
@@ -850,6 +852,10 @@ let perspective = stringProp("perspective");
 let selector = (name, rules) => Selector(name, rules);
 
 let hover = selector(":hover");
+
+let before = selector("::before");
+
+let after = selector("::after");
 
 let disabled = selector(":disabled");
 

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -49,6 +49,8 @@ let mm: float => cssunit;
 
 let zero: cssunit;
 
+let auto: cssunit;
+
 /* color */
 let rgb: (int, int, int) => color;
 
@@ -512,6 +514,10 @@ let visited: list(rule) => rule;
 let active: list(rule) => rule;
 
 let hover: list(rule) => rule;
+
+let before: list(rule) => rule;
+
+let after: list(rule) => rule;
 
 let firstChild: list(rule) => rule;
 


### PR DESCRIPTION
Thank you for a great binding!

With this pullrequest I added cssunit auto because it was missing. Now we can put auto for height etc but we can also put auto for font-size which is a invalid property value.

```ocaml
let appStyles =
  Css.(
    {
      "wrapper":
        style([maxWidth(StyleConstants.appWidth), marginLeft(Css.auto), marginRight(Css.auto)])
    }
  );
```

I also added selectors for before and after. They work as other selectors like hover.
```ocaml
style([
          before([
            position(Absolute),
            borderLeft(px(4), Solid, Colors.transparent),
            borderRight(px(4), Solid, Colors.transparent),
            borderBottom(px(4), Solid, Colors.darkGray)])
        ]),
```