### PR TITLE
better escape hatches

### DIFF
--- a/src/Css.re
+++ b/src/Css.re
@@ -419,7 +419,7 @@ let turn = i => {j|$(i)turn|j};
 /*********
  * CSS RULES
  **********/
-let unsafe = (name, value) => Property(name, value);
+let unsafe = (name, value) => Property(name, Obj.magic(value));
 
 type visibility =
   | Visible

--- a/src/Css.re
+++ b/src/Css.re
@@ -65,6 +65,8 @@ let important = v =>
   | _ => v
   };
 
+let unsafeValue: string => 'a = Obj.magic;
+
 
 /*********
  * COLORS

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -361,7 +361,7 @@ let yellow: color;
 let yellowgreen: color;
 
 /* CSS RULES */
-let unsafe: (string, string) => rule;
+let unsafe: (string, 'a) => rule;
 
 type visibility =
   | Visible

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -12,6 +12,8 @@ type transform;
 
 type angle;
 
+let unsafeValue: string => 'a;
+
 let rad: float => angle;
 
 let deg: float => angle;


### PR DESCRIPTION
This does two things:
1. makes `unsafe` take any value, so it can be used with constants defined in themes and such.
2. adds `unsafeValue` which just casts a string to any value. It enables using prop functions for unsupported values, and is therefore safer than just using `unsafe` 