### PR TITLE
Adding support for calc() function

### DIFF
--- a/src/Css.re
+++ b/src/Css.re
@@ -1627,10 +1627,7 @@ module SVG = {
   let strokeOpacity = (v) => Property("strokeOpacity", {j|$v|j});
 };
 
-type operator = string;
-
-let addition = "+";
-
-let subtraction = "-";
-
-let calc = (x: cssunit, y: cssunit, operator: operator) => "calc(" ++ x ++ " " ++ operator ++ " " ++ y ++ ")";
+module Calc = {
+  let (-) = (a, b) => {j|calc($(a) - $(b))|j};
+  let (+) = (a, b) => {j|calc($(a) + $(b))|j};
+};

--- a/src/Css.re
+++ b/src/Css.re
@@ -1626,3 +1626,11 @@ module SVG = {
   let strokeWidth = stringProp("strokeWidth");
   let strokeOpacity = (v) => Property("strokeOpacity", {j|$v|j});
 };
+
+type operator = string;
+
+let addition = "+";
+
+let subtraction = "-";
+
+let calc = (x: cssunit, y: cssunit, operator: operator) => "calc(" ++ x ++ " " ++ operator ++ " " ++ y ++ ")";

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -1064,3 +1064,11 @@ module SVG: {
   let strokeWidth: cssunit => rule;
   let strokeOpacity: float => rule;
 };
+
+type operator;
+
+let addition: operator;
+
+let subtraction: operator;
+
+let calc: (cssunit, cssunit, operator) => cssunit;

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -1065,10 +1065,7 @@ module SVG: {
   let strokeOpacity: float => rule;
 };
 
-type operator;
-
-let addition: operator;
-
-let subtraction: operator;
-
-let calc: (cssunit, cssunit, operator) => cssunit;
+module Calc: {
+  let (-): (cssunit, cssunit) => cssunit;
+  let (+): (cssunit, cssunit) => cssunit;
+};


### PR DESCRIPTION
# Description

Added support to use the css `calc()` function.
Created a `calc` function which takes three parameters as argument: `(cssunit, cssunit, operator)` and construct a `cssunit`: `calc(cssunit operator cssunit)`.
Also created a new type `operator` which can either have the value `addition = "+"` or `subtraction = "-"`.

If you want this implemented in some other way than just let me know!
I have never submitted a PR to a open source library before so if there is anything wrong here just let me know 😈 

# Example

```
let styles =
  Css.(
    {
      "container": style([
          position(Absolute),
          top(calc(pct(50.0), px(23), subtraction))
       ])
    }
  )
``` 