### PR TITLE
Added open Css; to the top of the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ In your `bsconfig.json`, include `"bs-css"` in the `bs-dependencies`.
 ## Usage
 
 ```reason
-/*Open the Css module, so we can access the style properties below without prefixing them with Css.*/
-open Css;
+
 
 module Styles = {
+  /*Open the Css module, so we can access the style properties below without prefixing them with Css.*/
+  open Css;
+  
   let card = style([
     display(flexBox),
     flexDirection(column), 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ In your `bsconfig.json`, include `"bs-css"` in the `bs-dependencies`.
 ## Usage
 
 ```reason
+/*Open the Css module, so we can access the style properties below without prefixing them with Css.*/
+open Css;
 
 module Styles = {
   let card = style([


### PR DESCRIPTION
So I'm completely new to both OCaml and Reason, so I might just have completely misunderstood something.
But I couldn't get the sample to work, because my project couldn't find style or backgroundColor (etc.). I found at that if I accessed them in the module (as is done in the example in the example folder) everything works as expected.

I don't know what's considered good or bad practice yet, but I like the idea of opening the Css module at the top to make it easier to access all the styling properties. 

I'm sorry if I've misunderstood something! :)