### PR TITLE
Preserve style definition order

### DIFF
--- a/src/Css.re
+++ b/src/Css.re
@@ -35,7 +35,7 @@ module Glamor = {
       };
     ruleset |> List.map(toJs) |> Js.Dict.fromList |> Js.Json.object_;
   };
-  let make = rules => rules |> List.rev |> makeDict |> _make;
+  let make = rules => rules |> makeDict |> _make;
 };
 
 type declaration = [ | `declaration(string, string)];


### PR DESCRIPTION
Hi there :wave:

We've been using bs-css for a while and we just updated to 6.3.1. It's a great change on all accounts except we noticed a few styles broke. It seems to only occur for styles like this:

```
className=(
  style(
    merge([
      Styles.input,
      [
        wordWrap(`normal),
        width(px(120)),
        padding2(~v=px(6), ~h=px(8)),
        fontSize(Styles.FontSize.small)
      ]
    ])
  )
)
```

What happens in this case is that `Styles.input` contains a `fontSize` which we assumed would be overwritten by the one declared later. This was the behavior in previous versions.

I traced the problem to this line: https://github.com/SentiaAnalytics/bs-css/blob/master/src/Css.re#L38.

This patch fixed our issue. I'm not aware of any side effects from removing the `List.rev` application.