### PR TITLE
Add support for pointerEvents

### DIFF
--- a/src/Css.re
+++ b/src/Css.re
@@ -1155,6 +1155,14 @@ let wordWrap = x =>
     | `breakWord => "break-word"
   });
 
+let string_of_pointerEvents =
+  fun
+  | `auto => "auto"
+  | `none => "none";
+
+let pointerEvents = x => d("pointerEvents", string_of_pointerEvents(x));
+
+
 /**
  * Transform
  */

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -569,6 +569,8 @@ let outlineWidth : length => rule;
 let outlineColor : color => rule;
 let outlineOffset : length => rule;
 
+let pointerEvents : [ |`auto | `none] => rule;
+
 
 /**
  * Text


### PR DESCRIPTION
Hey 👋 

This PR adds support for the `pointerEvents` property.
Did only add support for the default values (`auto` and `none`),  not the SVG specific ones.

Here are the docs for it https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events.

