### PR TITLE
CSS grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "bs-jest": "^0.1.0",
-    "bs-platform": "^2.2.3",
+    "bs-platform": "3",
     "reason-react": "^0.3.4",
     "webpack": "^3.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "bs-jest": "^0.1.0",
-    "bs-platform": "3",
+    "bs-platform": "^3.0.0",
     "reason-react": "^0.3.4",
     "webpack": "^3.8.1"
   },

--- a/src/Css.re
+++ b/src/Css.re
@@ -366,6 +366,7 @@ let ch = x => `ch(x);
 let cm = x => `cm(x);
 let em = x => `em(x);
 let ex = x => `ex(x);
+let fr = x => `fr(x);
 let mm = x => `mm(x);
 let pct = x => `percent(x);
 let pt = x => `pt(x);
@@ -537,6 +538,8 @@ let display = x =>
     | `none => "none"
     | `flex => "flex"
     | `inlineFlex => "inline-flex"
+    | `grid => "grid"
+    | `inlineGrid => "inline-grid"
     });
 
 let position = x =>
@@ -660,6 +663,42 @@ let minWidth = x => d("minWidth", string_of_dimension(x));
 let height = x => d("height", string_of_dimension(x));
 let minHeight = x => d("minHeight", string_of_dimension(x));
 let maxHeight = x => d("maxHeight", string_of_dimension(x));
+
+let string_of_dimensions = dimensions =>
+  dimensions
+  |> List.map(string_of_dimension)
+  |> String.concat(" ");
+
+let gridTemplateColumns = dimensions =>
+  d("gridTemplateColumns", string_of_dimensions(dimensions));
+
+let gridTemplateRows = dimensions =>
+  d("gridTemplateRows", string_of_dimensions(dimensions));
+
+let gridAutoRows = dimensions =>
+  d("gridAutoRows", string_of_dimension(dimensions));
+
+let gridColumnStart = n =>
+  d("gridColumnStart", string_of_int(n));
+
+let gridColumnEnd = n =>
+  d("gridColumnEnd", string_of_int(n));
+
+let gridRowStart = n =>
+  d("gridRowStart", string_of_int(n));
+
+let gridRowEnd = n =>
+  d("gridRowEnd", string_of_int(n));
+
+let gridColumnGap = n =>
+  d("gridColumnGap", string_of_length(n));
+
+let gridRowGap = n =>
+  d("gridRowGap", string_of_length(n));
+
+let gridGap = n =>
+  d("gridGap", string_of_length(n));
+
 
 let string_of_align =
   fun

--- a/src/Css.re
+++ b/src/Css.re
@@ -52,8 +52,8 @@ module Glamor = {
 };
 
 type declaration = [ | `declaration(string, string)];
-type rule = [ 
-  | `selector(string, list(rule)) 
+type rule = [
+  | `selector(string, list(rule))
   | `declaration(string, string)
   | `animation(string)
   | `transition(string)
@@ -96,8 +96,8 @@ let label = (label) => `declaration("label", label);
 /********************************************************
  ************************ VALUES ************************
  ********************************************************/
-type angle = [ 
-  | `deg(int) 
+type angle = [
+  | `deg(int)
   | `rad(float)
   | `grad(float)
   | `turn(float)
@@ -773,14 +773,14 @@ let borderLeft = (px, style, color) =>
 let borderLeftWidth = x => d("borderLeftWidth", string_of_length(x));
 let borderLeftStyle = x => d("borderLeftStyle", string_of_borderstyle(x));
 let borderLeftColor = x => d("borderLeftColor", string_of_color(x));
-  
+
 let borderRight = (px, style, color) =>
   d( "borderRight", join( " ", [
     string_of_length(px),
     string_of_borderstyle(style),
     string_of_color(color)
     ]));
-    
+
 let borderRightWidth = x => d("borderRightWidth", string_of_length(x));
 let borderRightColor = x => d("borderRightColor", string_of_color(x));
 let borderRightStyle = x => d("borderRightStyle", string_of_borderstyle(x));
@@ -1333,7 +1333,7 @@ let transition = (~duration=0, ~delay=0, ~timingFunction=`ease, property) =>
     property
   ]));
 
-let transitions = xs => 
+let transitions = xs =>
   d("transition", xs |> List.map(fun | `transition(s) => s) |> join(", "));
 
 let transitionDelay = i => d("transitionDelay", string_of_int(i) ++ "ms");

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -1,5 +1,5 @@
-type rule = [ 
-  | `selector(string, list(rule)) 
+type rule = [
+  | `selector(string, list(rule))
   | `declaration(string, string)
   | `animation(string)
   | `transition(string)
@@ -230,6 +230,7 @@ let ch : float => [> | `ch(float)];
 let cm : float => [> | `cm(float)];
 let em : float => [> | `em(float)];
 let ex : float => [> | `ex(float)];
+let fr : float => [> | `fr(float)];
 let mm : float => [> | `mm(float)];
 let pct : float => [> | `percent(float)];
 let pt : int => [> | `pt(int)];
@@ -243,7 +244,7 @@ let zero : [> | `zero];
 
 
 module Calc: {
-  let (-): (length, length) => [> |length];
+  let (-): (length, length) => [> | length];
   let (+): (length, length) => [> | length];
 };
 
@@ -400,7 +401,7 @@ let unsafe : (string, string) => rule;
  * Layout
 */
 
-let display : [ | `flex | `block | `inline | `inlineBlock | `none | `inlineFlex ] => rule;
+let display : [ | `flex | `block | `inline | `inlineBlock | `none | `inlineFlex | `grid | `inlineGrid ] => rule;
 let position : [ | `absolute | `relative | `static | `fixed | `sticky ] => rule;
 
 let top : [ | length] => rule;
@@ -416,6 +417,17 @@ let flexBasis: [ | length | `auto | `fill | `content | `maxContent | `minContent
 let flexDirection: [ | `row | `column | `rowReverse | `columnReverse] => rule;
 let flexWrap: [ | `wrap | `nowrap | `wrapReverse] => rule;
 let order: int => rule;
+
+let gridTemplateColumns : list([ | length | `auto]) => rule;
+let gridTemplateRows : list([ | length | `auto]) => rule;
+let gridAutoRows : [ | length | `auto] => rule;
+let gridColumnStart : int => rule;
+let gridColumnEnd : int => rule;
+let gridRowStart : int => rule;
+let gridRowEnd : int => rule;
+let gridColumnGap : length => rule;
+let gridRowGap : length => rule;
+let gridGap : length => rule;
 
 let width : [ | length | `auto ] => rule;
 let minWidth : [ | length | `auto ] => rule;
@@ -442,15 +454,15 @@ let paddingRight : length => rule;
 let paddingTop : length => rule;
 let paddingBottom : length => rule;
 
-let alignContent : [ | `stretch | `flexStart | `center | `flexEnd | `spaceBetween | `spaceAround] => rule; 
-let alignItems : [ | `stretch | `flexStart | `center | `flexEnd | `baseline ] => rule; 
-let alignSelf : [ | `stretch | `flexStart | `center | `flexEnd | `baseline | `auto ] => rule; 
-let justifyContent : [ | `flexStart | `center | `flexEnd | `spaceBetween | `spaceAround] => rule; 
+let alignContent : [ | `stretch | `flexStart | `center | `flexEnd | `spaceBetween | `spaceAround] => rule;
+let alignItems : [ | `stretch | `flexStart | `center | `flexEnd | `baseline ] => rule;
+let alignSelf : [ | `stretch | `flexStart | `center | `flexEnd | `baseline | `auto ] => rule;
+let justifyContent : [ | `flexStart | `center | `flexEnd | `spaceBetween | `spaceAround] => rule;
 
 let boxSizing : [ | `borderBox | `contentBox] => rule;
 
-let float: [ | `left | `right| `none ] => rule; 
-let clear: [ | `left | `right | `both ] => rule; 
+let float: [ | `left | `right| `none ] => rule;
+let clear: [ | `left | `right | `both ] => rule;
 
 let overflow: [ | `hidden | `visible | `scroll | `auto] => rule;
 let overflowX: [ | `hidden | `visible | `scroll | `auto] => rule;
@@ -511,13 +523,13 @@ let backgroundPosition: ([ | length], [ | length]) => rule;
 let backgroundRepeat: [ | `repeat | `noRepeat | `repeatX | `repeatY] => rule;
 let backgroundSize: [ | `size(length, length) | `auto | `cover | `contain] => rule;
 
-let cursor : [ 
+let cursor : [
   | `pointer
   | `alias
   | `allScroll
   | `auto
-  | `cell 
-  | `contextMenu 
+  | `cell
+  | `contextMenu
   | `default
   | `none
   | `crosshair
@@ -594,7 +606,7 @@ let fontVariant : [ | `normal | `smallCaps] => rule;
 let fontStyle: fontStyle => rule;
 let fontWeight : int => rule;
 let letterSpacing: [ `normal | length] => rule;
-let lineHeight: float => rule; 
+let lineHeight: float => rule;
 let textAlign : [ | `left | `center | `right | `justify] => rule;
 let textDecoration : [ | `none | `underline | `overline | `lineThrough ] => rule;
 let textDecorationColor : color => rule;
@@ -621,16 +633,16 @@ type transform = [
    | `translateX(length)
    | `translateY(length)
    | `translateZ(length)
-   | `scale(float, float) 
-   | `scale3d(float, float, float) 
-   | `scaleX(float) 
-   | `scaleY(float) 
-   | `scaleZ(float) 
-   | `rotate(angle) 
-   | `rotate3d(float, float, float, angle) 
-   | `rotateX(angle) 
-   | `rotateY(angle) 
-   | `rotateZ(angle) 
+   | `scale(float, float)
+   | `scale3d(float, float, float)
+   | `scaleX(float)
+   | `scaleY(float)
+   | `scaleZ(float)
+   | `rotate(angle)
+   | `rotate3d(float, float, float, angle)
+   | `rotateX(angle)
+   | `rotateY(angle)
+   | `rotateZ(angle)
    | `skew(angle, angle)
    | `skewX(angle)
    | `skewY(angle)
@@ -643,7 +655,7 @@ type transform = [
  let transformOrigin3d: (length, length, length) => rule;
  let transformStyle: [ | `preserve3d | `flat] => rule;
  let perspective : [ `none | length] => rule;
- let perspectiveOrigin: (length, length) => rule; 
+ let perspectiveOrigin: (length, length) => rule;
 
  /**
   * Transition
@@ -671,7 +683,7 @@ let transitionProperty : string => rule;
  * Animation
  */
 
-type animation; 
+type animation;
 let keyframes : list((int, list(rule))) => animation;
 
 type animationDirection = [
@@ -684,11 +696,11 @@ type animationDirection = [
 type animationFillMode = [ | `none | `forwards | `backwards | `both ];
 type animationIterationCount = [ | `infinite | `count(int) ];
 type animationPlayState = [ | `paused | `running ];
-   
+
 let animation : (
-  ~duration:int=?, 
-  ~delay:int=?, 
-  ~direction:animationDirection=?, 
+  ~duration:int=?,
+  ~delay:int=?,
+  ~direction:animationDirection=?,
   ~timingFunction:timingFunction=?,
   ~fillMode:animationFillMode=?,
   ~playState:animationPlayState=?,
@@ -696,14 +708,14 @@ let animation : (
   animation
   ) => [> | `animation(string)];
 let animations : list([ | `animation(string)]) => rule;
-  
+
 let animationDelay : int => rule;
 let animationDirection : animationDirection => rule;
 let animationDuration : int => rule;
 let animationFillMode : animationFillMode => rule;
 let animationIterationCount: [ | `infinite | `count(int)] => rule;
 let animationName : animation => rule;
-let animationPlayState : [ | `paused | `running] => rule;  
+let animationPlayState : [ | `paused | `running] => rule;
 let animationTimingFunction : timingFunction => rule;
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -481,9 +481,9 @@ bs-jest@^0.1.0:
   dependencies:
     jest "^19.0.2"
 
-bs-platform@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.2.3.tgz#d905ae10a5f3621e6a739041dfa0b58483a2174f"
+bs-platform@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.0.0.tgz#38f200730db52fdea37819376b6ac3dfb20244c0"
 
 bser@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Update to latest bs-platform, Css.re failed to compile for me with this older version.

## CSS grid support

- https://www.mozilla.org/en-US/developer/css-grid/
- https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout

Have not included the minmax function and I don't know how to type it
here.

https://developer.mozilla.org/en-US/docs/Web/CSS/minmax