### PR TITLE
Add support for clipPath with url

### DIFF
--- a/src/Css.re
+++ b/src/Css.re
@@ -968,6 +968,11 @@ let cursor = x =>
     | `zoomOut => "zoom-out"
     });
 
+let clipPath = x =>
+  d( "clipPath", switch x {
+    | `url(url) => "url(" ++ url ++ ")"
+    });
+
 type listStyleType = [
   | `disc
   | `circle

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -552,6 +552,10 @@ let cursor : [
   | `zoomOut
   ] => rule;
 
+let clipPath : [
+  |`url(string)
+  ] =>
+  rule;
 
 type listStyleType = [
  | `disc


### PR DESCRIPTION
Adding support for clipPath. 
Only added a support for `url` 

Here are the docs for it https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path 
