### PR TITLE
[RFC] Feature: Minimal Css Variable support

### DIFF
--- a/example/example.re
+++ b/example/example.re
@@ -19,13 +19,13 @@ module Styles = {
     ]);
 };
 
-let text = ReasonReact.stringToElement;
+let text = ReasonReact.string;
 
 module Page = {
   let component = ReasonReact.statelessComponent("Page");
-  let make = (_) => {
+  let make = _ => {
     ...component,
-    render: (_) => <div> <div className=Styles.page> Test.tests </div> </div>,
+    render: _ => <div> <div className=Styles.page> Test.tests </div> </div>,
   };
 };
 

--- a/example/test.re
+++ b/example/test.re
@@ -1,4 +1,4 @@
-let text = ReasonReact.stringToElement;
+let text = ReasonReact.string;
 
 let arialNarrow =
   Css.(
@@ -63,7 +63,7 @@ module Section = {
   let component = ReasonReact.statelessComponent("Section");
   let make = (~name, children) => {
     ...component,
-    render: (_) =>
+    render: _ =>
       <section className=(Css.style(section))>
         <h1> (text(name)) </h1>
         (

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
       "requires": {
-        "acorn": "^4.0.3"
+        "acorn": "4.0.13"
       }
     },
     "acorn-globals": {
@@ -31,7 +31,7 @@
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "dev": true,
       "requires": {
-        "acorn": "^4.0.4"
+        "acorn": "4.0.13"
       }
     },
     "ajv": {
@@ -40,10 +40,10 @@
       "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "json-schema-traverse": "^0.3.0",
-        "json-stable-stringify": "^1.0.1"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "json-schema-traverse": "0.3.1",
+        "json-stable-stringify": "1.0.1"
       }
     },
     "ajv-keywords": {
@@ -58,9 +58,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "amdefine": {
@@ -93,8 +93,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "append-transform": {
@@ -103,7 +103,7 @@
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
       "dev": true,
       "requires": {
-        "default-require-extensions": "^1.0.0"
+        "default-require-extensions": "1.0.0"
       }
     },
     "argparse": {
@@ -112,7 +112,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -121,7 +121,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -165,9 +165,9 @@
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "assert": {
@@ -191,7 +191,7 @@
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "4.17.4"
       }
     },
     "async-each": {
@@ -224,9 +224,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "babel-core": {
@@ -235,25 +235,25 @@
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "debug": "^2.6.8",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.7",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.6"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.0",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       }
     },
     "babel-generator": {
@@ -262,14 +262,14 @@
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.6",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       }
     },
     "babel-helpers": {
@@ -278,8 +278,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-jest": {
@@ -288,9 +288,9 @@
       "integrity": "sha1-WTI87ZmjqE01naIZyogQdP/Gzj8=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.0.0",
-        "babel-plugin-istanbul": "^4.0.0",
-        "babel-preset-jest": "^19.0.0"
+        "babel-core": "6.26.0",
+        "babel-plugin-istanbul": "4.1.5",
+        "babel-preset-jest": "19.0.0"
       }
     },
     "babel-messages": {
@@ -299,7 +299,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -308,9 +308,9 @@
       "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0",
-        "istanbul-lib-instrument": "^1.7.5",
-        "test-exclude": "^4.1.1"
+        "find-up": "2.1.0",
+        "istanbul-lib-instrument": "1.8.0",
+        "test-exclude": "4.1.1"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -325,7 +325,7 @@
       "integrity": "sha1-ItZyAdAjJKGVgRKI6zgpS7PKw5Y=",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^19.0.0"
+        "babel-plugin-jest-hoist": "19.0.0"
       }
     },
     "babel-register": {
@@ -334,13 +334,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       },
       "dependencies": {
         "core-js": {
@@ -357,8 +357,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
       },
       "dependencies": {
         "core-js": {
@@ -375,11 +375,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.4"
       }
     },
     "babel-traverse": {
@@ -388,15 +388,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
       }
     },
     "babel-types": {
@@ -405,10 +405,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -436,7 +436,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "big.js": {
@@ -463,7 +463,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.0"
       }
     },
     "bowser": {
@@ -477,7 +477,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -487,9 +487,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "brorand": {
@@ -521,12 +521,12 @@
       "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "dev": true,
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "browserify-cipher": {
@@ -535,9 +535,9 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.1.1",
+        "browserify-des": "1.0.0",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -546,9 +546,9 @@
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
       }
     },
     "browserify-rsa": {
@@ -557,8 +557,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.5"
       }
     },
     "browserify-sign": {
@@ -567,13 +567,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.0"
       }
     },
     "browserify-zlib": {
@@ -582,7 +582,7 @@
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
-        "pako": "~0.2.0"
+        "pako": "0.2.9"
       }
     },
     "bs-jest": {
@@ -591,7 +591,7 @@
       "integrity": "sha1-M8OoHUmA7I3el7XIOYxTiN8muFk=",
       "dev": true,
       "requires": {
-        "jest": "^19.0.2"
+        "jest": "19.0.2"
       }
     },
     "bs-platform": {
@@ -606,7 +606,7 @@
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
-        "node-int64": "^0.4.0"
+        "node-int64": "0.4.0"
       }
     },
     "buffer": {
@@ -615,9 +615,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.2.1",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
       }
     },
     "buffer-xor": {
@@ -662,8 +662,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chalk": {
@@ -672,11 +672,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "chokidar": {
@@ -685,15 +685,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.2",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "ci-info": {
@@ -708,8 +708,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "cliui": {
@@ -718,8 +718,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -749,7 +749,7 @@
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -764,7 +764,7 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "concat-map": {
@@ -779,7 +779,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "constants-browserify": {
@@ -817,8 +817,8 @@
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
       }
     },
     "create-hash": {
@@ -827,10 +827,10 @@
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "sha.js": "2.4.9"
       }
     },
     "create-hmac": {
@@ -839,12 +839,12 @@
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.9"
       }
     },
     "cross-spawn": {
@@ -853,9 +853,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "cryptiles": {
@@ -864,7 +864,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -873,7 +873,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.0"
           }
         }
       }
@@ -884,16 +884,16 @@
       "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "browserify-cipher": "1.0.0",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.0",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "diffie-hellman": "5.0.2",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.14",
+        "public-encrypt": "4.0.0",
+        "randombytes": "2.0.5"
       }
     },
     "css-in-js-utils": {
@@ -901,7 +901,7 @@
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz",
       "integrity": "sha512-yuWmPMD9FLi50Xf3k8W8oO3WM1eVnxEGCldCLyfusQ+CgivFk0s23yst4ooW6tfxMuSa03S6uUEga9UhX6GRrA==",
       "requires": {
-        "hyphenate-style-name": "^1.0.2"
+        "hyphenate-style-name": "1.0.2"
       }
     },
     "cssom": {
@@ -916,7 +916,7 @@
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
       "requires": {
-        "cssom": "0.3.x"
+        "cssom": "0.3.2"
       }
     },
     "d": {
@@ -925,7 +925,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.35"
       }
     },
     "dashdash": {
@@ -934,7 +934,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "date-now": {
@@ -970,7 +970,7 @@
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
       "dev": true,
       "requires": {
-        "strip-bom": "^2.0.0"
+        "strip-bom": "2.0.0"
       }
     },
     "delayed-stream": {
@@ -985,8 +985,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "detect-indent": {
@@ -995,7 +995,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "diff": {
@@ -1010,9 +1010,9 @@
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.5"
       }
     },
     "domain-browser": {
@@ -1028,7 +1028,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "elliptic": {
@@ -1037,13 +1037,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "emojis-list": {
@@ -1057,7 +1057,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.19"
       }
     },
     "enhanced-resolve": {
@@ -1066,10 +1066,10 @@
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
-        "object-assign": "^4.0.1",
-        "tapable": "^0.2.7"
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "object-assign": "4.1.1",
+        "tapable": "0.2.8"
       }
     },
     "errno": {
@@ -1078,7 +1078,7 @@
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
       "requires": {
-        "prr": "~0.0.0"
+        "prr": "0.0.0"
       }
     },
     "error-ex": {
@@ -1087,7 +1087,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es5-ext": {
@@ -1096,8 +1096,8 @@
       "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.1",
-        "es6-symbol": "~3.1.1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-iterator": {
@@ -1106,9 +1106,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-map": {
@@ -1117,12 +1117,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
       }
     },
     "es6-set": {
@@ -1131,11 +1131,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
+        "event-emitter": "0.3.5"
       }
     },
     "es6-symbol": {
@@ -1144,8 +1144,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
       }
     },
     "es6-weak-map": {
@@ -1154,10 +1154,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -1172,11 +1172,11 @@
       "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.5.6"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "esprima": {
@@ -1193,10 +1193,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "^0.1.3",
-        "es6-weak-map": "^2.0.1",
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
       }
     },
     "esprima": {
@@ -1211,8 +1211,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0",
-        "object-assign": "^4.0.1"
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
       }
     },
     "estraverse": {
@@ -1233,8 +1233,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
       }
     },
     "events": {
@@ -1249,8 +1249,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.1"
       }
     },
     "exec-sh": {
@@ -1259,7 +1259,7 @@
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
-        "merge": "^1.1.3"
+        "merge": "1.2.0"
       }
     },
     "execa": {
@@ -1268,13 +1268,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "expand-brackets": {
@@ -1283,7 +1283,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -1292,7 +1292,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.3"
       }
     },
     "extend": {
@@ -1307,7 +1307,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extsprintf": {
@@ -1334,7 +1334,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.0.0"
       }
     },
     "fbjs": {
@@ -1342,13 +1342,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.9"
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.17"
       }
     },
     "filename-regex": {
@@ -1363,8 +1363,8 @@
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.3",
-        "minimatch": "^3.0.3"
+        "glob": "7.1.2",
+        "minimatch": "3.0.4"
       }
     },
     "fill-range": {
@@ -1373,11 +1373,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "find-up": {
@@ -1386,7 +1386,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "2.0.0"
       }
     },
     "for-in": {
@@ -1401,7 +1401,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "forever-agent": {
@@ -1416,9 +1416,9 @@
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.5",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
       }
     },
     "fs.realpath": {
@@ -1434,8 +1434,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.3.0",
-        "node-pre-gyp": "^0.6.36"
+        "nan": "2.7.0",
+        "node-pre-gyp": "0.6.36"
       },
       "dependencies": {
         "abbrev": {
@@ -2030,15 +2030,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "request": "^2.81.0",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
           }
         },
         "nopt": {
@@ -2457,7 +2457,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glamor": {
@@ -2465,11 +2465,11 @@
       "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
       "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
       "requires": {
-        "fbjs": "^0.8.12",
-        "inline-style-prefixer": "^3.0.6",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.5.10",
-        "through": "^2.3.8"
+        "fbjs": "0.8.16",
+        "inline-style-prefixer": "3.0.8",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0",
+        "through": "2.3.8"
       }
     },
     "glob": {
@@ -2478,12 +2478,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -2492,8 +2492,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -2502,7 +2502,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "globals": {
@@ -2529,10 +2529,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "async": {
@@ -2547,7 +2547,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -2564,8 +2564,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.2.3",
+        "har-schema": "2.0.0"
       }
     },
     "has-ansi": {
@@ -2574,7 +2574,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -2589,7 +2589,7 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "hash.js": {
@@ -2598,8 +2598,8 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "hawk": {
@@ -2608,10 +2608,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.0.2"
       }
     },
     "hmac-drbg": {
@@ -2620,9 +2620,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoek": {
@@ -2637,8 +2637,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "hosted-git-info": {
@@ -2653,7 +2653,7 @@
       "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "^1.0.1"
+        "whatwg-encoding": "1.0.1"
       }
     },
     "http-signature": {
@@ -2662,9 +2662,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
       }
     },
     "https-browserify": {
@@ -2701,8 +2701,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -2716,8 +2716,8 @@
       "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
       "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
       "requires": {
-        "bowser": "^1.7.3",
-        "css-in-js-utils": "^2.0.0"
+        "bowser": "1.8.0",
+        "css-in-js-utils": "2.0.0"
       }
     },
     "interpret": {
@@ -2732,7 +2732,7 @@
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "invert-kv": {
@@ -2753,7 +2753,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.10.0"
       }
     },
     "is-buffer": {
@@ -2768,7 +2768,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-ci": {
@@ -2777,7 +2777,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.1"
       }
     },
     "is-dotfile": {
@@ -2792,7 +2792,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -2813,7 +2813,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -2822,7 +2822,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-glob": {
@@ -2831,7 +2831,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-number": {
@@ -2840,7 +2840,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-posix-bracket": {
@@ -2898,8 +2898,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
       }
     },
     "isstream": {
@@ -2914,17 +2914,17 @@
       "integrity": "sha1-JbxXAffGgMD//5E95G42GaOm5oA=",
       "dev": true,
       "requires": {
-        "async": "^2.1.4",
-        "fileset": "^2.0.2",
-        "istanbul-lib-coverage": "^1.1.1",
-        "istanbul-lib-hook": "^1.0.7",
-        "istanbul-lib-instrument": "^1.8.0",
-        "istanbul-lib-report": "^1.1.1",
-        "istanbul-lib-source-maps": "^1.2.1",
-        "istanbul-reports": "^1.1.2",
-        "js-yaml": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "once": "^1.4.0"
+        "async": "2.5.0",
+        "fileset": "2.0.3",
+        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-hook": "1.0.7",
+        "istanbul-lib-instrument": "1.8.0",
+        "istanbul-lib-report": "1.1.1",
+        "istanbul-lib-source-maps": "1.2.1",
+        "istanbul-reports": "1.1.2",
+        "js-yaml": "3.10.0",
+        "mkdirp": "0.5.1",
+        "once": "1.4.0"
       }
     },
     "istanbul-lib-coverage": {
@@ -2939,7 +2939,7 @@
       "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
       "dev": true,
       "requires": {
-        "append-transform": "^0.4.0"
+        "append-transform": "0.4.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -2948,13 +2948,13 @@
       "integrity": "sha1-ZvbJQhzJ7EcE928tsIS6kHiitTI=",
       "dev": true,
       "requires": {
-        "babel-generator": "^6.18.0",
-        "babel-template": "^6.16.0",
-        "babel-traverse": "^6.18.0",
-        "babel-types": "^6.18.0",
-        "babylon": "^6.18.0",
-        "istanbul-lib-coverage": "^1.1.1",
-        "semver": "^5.3.0"
+        "babel-generator": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "istanbul-lib-coverage": "1.1.1",
+        "semver": "5.4.1"
       }
     },
     "istanbul-lib-report": {
@@ -2963,10 +2963,10 @@
       "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^1.1.1",
-        "mkdirp": "^0.5.1",
-        "path-parse": "^1.0.5",
-        "supports-color": "^3.1.2"
+        "istanbul-lib-coverage": "1.1.1",
+        "mkdirp": "0.5.1",
+        "path-parse": "1.0.5",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "supports-color": {
@@ -2975,7 +2975,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -2986,11 +2986,11 @@
       "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.3",
-        "istanbul-lib-coverage": "^1.1.1",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.1",
-        "source-map": "^0.5.3"
+        "debug": "2.6.9",
+        "istanbul-lib-coverage": "1.1.1",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "source-map": "0.5.7"
       }
     },
     "istanbul-reports": {
@@ -2999,7 +2999,7 @@
       "integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
       "dev": true,
       "requires": {
-        "handlebars": "^4.0.3"
+        "handlebars": "4.0.11"
       }
     },
     "jest": {
@@ -3008,7 +3008,7 @@
       "integrity": "sha1-t5T6r4/0Yec4jyi+71WaVPILLBA=",
       "dev": true,
       "requires": {
-        "jest-cli": "^19.0.2"
+        "jest-cli": "19.0.2"
       },
       "dependencies": {
         "jest-cli": {
@@ -3017,33 +3017,33 @@
           "integrity": "sha1-zDYgtirKxfLZOlSMtu9pfU7IVEM=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^1.4.0",
-            "callsites": "^2.0.0",
-            "chalk": "^1.1.1",
-            "graceful-fs": "^4.1.6",
-            "is-ci": "^1.0.9",
-            "istanbul-api": "^1.1.0-alpha.1",
-            "istanbul-lib-coverage": "^1.0.0",
-            "istanbul-lib-instrument": "^1.1.1",
-            "jest-changed-files": "^19.0.2",
-            "jest-config": "^19.0.2",
-            "jest-environment-jsdom": "^19.0.2",
-            "jest-haste-map": "^19.0.0",
-            "jest-jasmine2": "^19.0.2",
-            "jest-message-util": "^19.0.0",
-            "jest-regex-util": "^19.0.0",
-            "jest-resolve-dependencies": "^19.0.0",
-            "jest-runtime": "^19.0.2",
-            "jest-snapshot": "^19.0.2",
-            "jest-util": "^19.0.2",
-            "micromatch": "^2.3.11",
-            "node-notifier": "^5.0.1",
-            "slash": "^1.0.0",
-            "string-length": "^1.0.1",
-            "throat": "^3.0.0",
-            "which": "^1.1.1",
-            "worker-farm": "^1.3.1",
-            "yargs": "^6.3.0"
+            "ansi-escapes": "1.4.0",
+            "callsites": "2.0.0",
+            "chalk": "1.1.3",
+            "graceful-fs": "4.1.11",
+            "is-ci": "1.0.10",
+            "istanbul-api": "1.1.14",
+            "istanbul-lib-coverage": "1.1.1",
+            "istanbul-lib-instrument": "1.8.0",
+            "jest-changed-files": "19.0.2",
+            "jest-config": "19.0.4",
+            "jest-environment-jsdom": "19.0.2",
+            "jest-haste-map": "19.0.2",
+            "jest-jasmine2": "19.0.2",
+            "jest-message-util": "19.0.0",
+            "jest-regex-util": "19.0.0",
+            "jest-resolve-dependencies": "19.0.0",
+            "jest-runtime": "19.0.4",
+            "jest-snapshot": "19.0.2",
+            "jest-util": "19.0.2",
+            "micromatch": "2.3.11",
+            "node-notifier": "5.1.2",
+            "slash": "1.0.0",
+            "string-length": "1.0.1",
+            "throat": "3.2.0",
+            "which": "1.3.0",
+            "worker-farm": "1.5.0",
+            "yargs": "6.6.0"
           }
         }
       }
@@ -3060,14 +3060,14 @@
       "integrity": "sha1-QpgCEdRkF+kcp6v/0IbCcCNPc/0=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "jest-environment-jsdom": "^19.0.2",
-        "jest-environment-node": "^19.0.2",
-        "jest-jasmine2": "^19.0.2",
-        "jest-regex-util": "^19.0.0",
-        "jest-resolve": "^19.0.2",
-        "jest-validate": "^19.0.2",
-        "pretty-format": "^19.0.0"
+        "chalk": "1.1.3",
+        "jest-environment-jsdom": "19.0.2",
+        "jest-environment-node": "19.0.2",
+        "jest-jasmine2": "19.0.2",
+        "jest-regex-util": "19.0.0",
+        "jest-resolve": "19.0.2",
+        "jest-validate": "19.0.2",
+        "pretty-format": "19.0.0"
       }
     },
     "jest-diff": {
@@ -3076,10 +3076,10 @@
       "integrity": "sha1-0VY8/FbItgIymI+8BdTRbtkPBjw=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "diff": "^3.0.0",
-        "jest-matcher-utils": "^19.0.0",
-        "pretty-format": "^19.0.0"
+        "chalk": "1.1.3",
+        "diff": "3.4.0",
+        "jest-matcher-utils": "19.0.0",
+        "pretty-format": "19.0.0"
       }
     },
     "jest-environment-jsdom": {
@@ -3088,9 +3088,9 @@
       "integrity": "sha1-ztqFnEpLlKs15N59q1S5JvKT5KM=",
       "dev": true,
       "requires": {
-        "jest-mock": "^19.0.0",
-        "jest-util": "^19.0.2",
-        "jsdom": "^9.11.0"
+        "jest-mock": "19.0.0",
+        "jest-util": "19.0.2",
+        "jsdom": "9.12.0"
       }
     },
     "jest-environment-node": {
@@ -3099,8 +3099,8 @@
       "integrity": "sha1-boQHnbh+0h0MBeH5Zp8gexFv6Zs=",
       "dev": true,
       "requires": {
-        "jest-mock": "^19.0.0",
-        "jest-util": "^19.0.2"
+        "jest-mock": "19.0.0",
+        "jest-util": "19.0.2"
       }
     },
     "jest-file-exists": {
@@ -3115,11 +3115,11 @@
       "integrity": "sha1-KGSEw6Fuhtp4crCHfDXc4ww9bwc=",
       "dev": true,
       "requires": {
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.1.6",
-        "micromatch": "^2.3.11",
-        "sane": "~1.5.0",
-        "worker-farm": "^1.3.1"
+        "fb-watchman": "2.0.0",
+        "graceful-fs": "4.1.11",
+        "micromatch": "2.3.11",
+        "sane": "1.5.0",
+        "worker-farm": "1.5.0"
       }
     },
     "jest-jasmine2": {
@@ -3128,11 +3128,11 @@
       "integrity": "sha1-FnmRrIJZgfsagArxJug6/MqDLHM=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6",
-        "jest-matcher-utils": "^19.0.0",
-        "jest-matchers": "^19.0.0",
-        "jest-message-util": "^19.0.0",
-        "jest-snapshot": "^19.0.2"
+        "graceful-fs": "4.1.11",
+        "jest-matcher-utils": "19.0.0",
+        "jest-matchers": "19.0.0",
+        "jest-message-util": "19.0.0",
+        "jest-snapshot": "19.0.2"
       }
     },
     "jest-matcher-utils": {
@@ -3141,8 +3141,8 @@
       "integrity": "sha1-Xs2bY1ZdKwAfYfv37Ex/U3lkVk0=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "pretty-format": "^19.0.0"
+        "chalk": "1.1.3",
+        "pretty-format": "19.0.0"
       }
     },
     "jest-matchers": {
@@ -3151,10 +3151,10 @@
       "integrity": "sha1-x07Mbr/sBvOEdnuk1vpKQtZ1V1Q=",
       "dev": true,
       "requires": {
-        "jest-diff": "^19.0.0",
-        "jest-matcher-utils": "^19.0.0",
-        "jest-message-util": "^19.0.0",
-        "jest-regex-util": "^19.0.0"
+        "jest-diff": "19.0.0",
+        "jest-matcher-utils": "19.0.0",
+        "jest-message-util": "19.0.0",
+        "jest-regex-util": "19.0.0"
       }
     },
     "jest-message-util": {
@@ -3163,8 +3163,8 @@
       "integrity": "sha1-cheWuJwOTXYWBvm6jLgoo7YkZBY=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "micromatch": "^2.3.11"
+        "chalk": "1.1.3",
+        "micromatch": "2.3.11"
       }
     },
     "jest-mock": {
@@ -3185,9 +3185,9 @@
       "integrity": "sha1-V5NXXeTweuwy99f/DGwYGWPu+zw=",
       "dev": true,
       "requires": {
-        "browser-resolve": "^1.11.2",
-        "jest-haste-map": "^19.0.0",
-        "resolve": "^1.2.0"
+        "browser-resolve": "1.11.2",
+        "jest-haste-map": "19.0.2",
+        "resolve": "1.4.0"
       }
     },
     "jest-resolve-dependencies": {
@@ -3196,7 +3196,7 @@
       "integrity": "sha1-p0GtH6CUFA5k7PJkKlBPg07OIu4=",
       "dev": true,
       "requires": {
-        "jest-file-exists": "^19.0.0"
+        "jest-file-exists": "19.0.0"
       }
     },
     "jest-runtime": {
@@ -3205,21 +3205,21 @@
       "integrity": "sha1-8WfZ8TR3UvICc2EGeSZIU0n8wkU=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.0.0",
-        "babel-jest": "^19.0.0",
-        "babel-plugin-istanbul": "^4.0.0",
-        "chalk": "^1.1.3",
-        "graceful-fs": "^4.1.6",
-        "jest-config": "^19.0.2",
-        "jest-file-exists": "^19.0.0",
-        "jest-haste-map": "^19.0.0",
-        "jest-regex-util": "^19.0.0",
-        "jest-resolve": "^19.0.2",
-        "jest-util": "^19.0.2",
-        "json-stable-stringify": "^1.0.1",
-        "micromatch": "^2.3.11",
+        "babel-core": "6.26.0",
+        "babel-jest": "19.0.0",
+        "babel-plugin-istanbul": "4.1.5",
+        "chalk": "1.1.3",
+        "graceful-fs": "4.1.11",
+        "jest-config": "19.0.4",
+        "jest-file-exists": "19.0.0",
+        "jest-haste-map": "19.0.2",
+        "jest-regex-util": "19.0.0",
+        "jest-resolve": "19.0.2",
+        "jest-util": "19.0.2",
+        "json-stable-stringify": "1.0.1",
+        "micromatch": "2.3.11",
         "strip-bom": "3.0.0",
-        "yargs": "^6.3.0"
+        "yargs": "6.6.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -3236,13 +3236,13 @@
       "integrity": "sha1-nBshYhT3GHw4v9XHCx76sWsP9Qs=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "jest-diff": "^19.0.0",
-        "jest-file-exists": "^19.0.0",
-        "jest-matcher-utils": "^19.0.0",
-        "jest-util": "^19.0.2",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^19.0.0"
+        "chalk": "1.1.3",
+        "jest-diff": "19.0.0",
+        "jest-file-exists": "19.0.0",
+        "jest-matcher-utils": "19.0.0",
+        "jest-util": "19.0.2",
+        "natural-compare": "1.4.0",
+        "pretty-format": "19.0.0"
       }
     },
     "jest-util": {
@@ -3251,14 +3251,14 @@
       "integrity": "sha1-4KAjKiq55rK1Nmi9s1NMK1l37UE=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "graceful-fs": "^4.1.6",
-        "jest-file-exists": "^19.0.0",
-        "jest-message-util": "^19.0.0",
-        "jest-mock": "^19.0.0",
-        "jest-validate": "^19.0.2",
-        "leven": "^2.0.0",
-        "mkdirp": "^0.5.1"
+        "chalk": "1.1.3",
+        "graceful-fs": "4.1.11",
+        "jest-file-exists": "19.0.0",
+        "jest-message-util": "19.0.0",
+        "jest-mock": "19.0.0",
+        "jest-validate": "19.0.2",
+        "leven": "2.1.0",
+        "mkdirp": "0.5.1"
       }
     },
     "jest-validate": {
@@ -3267,10 +3267,10 @@
       "integrity": "sha1-3FNN9fEnjVtj3zKxQkHU2/ckTAw=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "jest-matcher-utils": "^19.0.0",
-        "leven": "^2.0.0",
-        "pretty-format": "^19.0.0"
+        "chalk": "1.1.3",
+        "jest-matcher-utils": "19.0.0",
+        "leven": "2.1.0",
+        "pretty-format": "19.0.0"
       }
     },
     "js-tokens": {
@@ -3284,8 +3284,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
       }
     },
     "jsbn": {
@@ -3301,25 +3301,25 @@
       "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
       "dev": true,
       "requires": {
-        "abab": "^1.0.3",
-        "acorn": "^4.0.4",
-        "acorn-globals": "^3.1.0",
-        "array-equal": "^1.0.0",
-        "content-type-parser": "^1.0.1",
-        "cssom": ">= 0.3.2 < 0.4.0",
-        "cssstyle": ">= 0.2.37 < 0.3.0",
-        "escodegen": "^1.6.1",
-        "html-encoding-sniffer": "^1.0.1",
-        "nwmatcher": ">= 1.3.9 < 2.0.0",
-        "parse5": "^1.5.1",
-        "request": "^2.79.0",
-        "sax": "^1.2.1",
-        "symbol-tree": "^3.2.1",
-        "tough-cookie": "^2.3.2",
-        "webidl-conversions": "^4.0.0",
-        "whatwg-encoding": "^1.0.1",
-        "whatwg-url": "^4.3.0",
-        "xml-name-validator": "^2.0.1"
+        "abab": "1.0.4",
+        "acorn": "4.0.13",
+        "acorn-globals": "3.1.0",
+        "array-equal": "1.0.0",
+        "content-type-parser": "1.0.1",
+        "cssom": "0.3.2",
+        "cssstyle": "0.2.37",
+        "escodegen": "1.9.0",
+        "html-encoding-sniffer": "1.0.1",
+        "nwmatcher": "1.4.3",
+        "parse5": "1.5.1",
+        "request": "2.83.0",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.3",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.1",
+        "whatwg-url": "4.8.0",
+        "xml-name-validator": "2.0.1"
       }
     },
     "jsesc": {
@@ -3352,7 +3352,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -3391,7 +3391,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.5"
       }
     },
     "lazy-cache": {
@@ -3406,7 +3406,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "leven": {
@@ -3421,8 +3421,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-json-file": {
@@ -3431,11 +3431,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       }
     },
     "loader-runner": {
@@ -3450,9 +3450,9 @@
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "dev": true,
       "requires": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0"
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1"
       }
     },
     "locate-path": {
@@ -3461,8 +3461,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -3482,7 +3482,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "lru-cache": {
@@ -3491,8 +3491,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "makeerror": {
@@ -3501,7 +3501,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.x"
+        "tmpl": "1.0.4"
       }
     },
     "md5.js": {
@@ -3510,8 +3510,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       },
       "dependencies": {
         "hash-base": {
@@ -3520,8 +3520,8 @@
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -3532,7 +3532,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.1.0"
       }
     },
     "memory-fs": {
@@ -3541,8 +3541,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.4",
+        "readable-stream": "2.3.3"
       }
     },
     "merge": {
@@ -3557,19 +3557,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "miller-rabin": {
@@ -3578,8 +3578,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mime-db": {
@@ -3594,7 +3594,7 @@
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "~1.30.0"
+        "mime-db": "1.30.0"
       }
     },
     "mimic-fn": {
@@ -3621,7 +3621,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -3663,8 +3663,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-int64": {
@@ -3679,28 +3679,28 @@
       "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
       "dev": true,
       "requires": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.1.4",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^1.0.0",
+        "assert": "1.4.1",
+        "browserify-zlib": "0.1.4",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.11.1",
+        "domain-browser": "1.1.7",
+        "events": "1.1.1",
         "https-browserify": "0.0.1",
-        "os-browserify": "^0.2.0",
+        "os-browserify": "0.2.1",
         "path-browserify": "0.0.0",
-        "process": "^0.11.0",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.0.5",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.3.1",
-        "string_decoder": "^0.10.25",
-        "timers-browserify": "^2.0.2",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.3",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.7.2",
+        "string_decoder": "0.10.31",
+        "timers-browserify": "2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.10.3",
+        "url": "0.11.0",
+        "util": "0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -3718,10 +3718,10 @@
       "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
       "dev": true,
       "requires": {
-        "growly": "^1.3.0",
-        "semver": "^5.3.0",
-        "shellwords": "^0.1.0",
-        "which": "^1.2.12"
+        "growly": "1.3.0",
+        "semver": "5.4.1",
+        "shellwords": "0.1.1",
+        "which": "1.3.0"
       }
     },
     "normalize-package-data": {
@@ -3730,10 +3730,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
       }
     },
     "normalize-path": {
@@ -3742,7 +3742,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "npm-run-path": {
@@ -3751,7 +3751,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
@@ -3783,8 +3783,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "once": {
@@ -3793,7 +3793,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "optimist": {
@@ -3802,8 +3802,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       }
     },
     "optionator": {
@@ -3812,12 +3812,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -3846,7 +3846,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -3873,7 +3873,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.1.0"
       }
     },
     "pako": {
@@ -3888,11 +3888,11 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
+        "asn1.js": "4.9.1",
+        "browserify-aes": "1.1.1",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.14"
       }
     },
     "parse-glob": {
@@ -3901,10 +3901,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-json": {
@@ -3913,7 +3913,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse5": {
@@ -3958,9 +3958,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "pbkdf2": {
@@ -3969,11 +3969,11 @@
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "dev": true,
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.9"
       }
     },
     "performance-now": {
@@ -4000,7 +4000,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "prelude-ls": {
@@ -4021,7 +4021,7 @@
       "integrity": "sha1-VlMNMqy5ij+khRxOK503tCBoTIQ=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.0.0"
+        "ansi-styles": "3.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4030,7 +4030,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.0"
           }
         }
       }
@@ -4058,7 +4058,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "prop-types": {
@@ -4066,9 +4066,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       }
     },
     "prr": {
@@ -4089,11 +4089,11 @@
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "parse-asn1": "5.1.0",
+        "randombytes": "2.0.5"
       }
     },
     "punycode": {
@@ -4126,8 +4126,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -4136,7 +4136,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4145,7 +4145,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.5"
               }
             }
           }
@@ -4156,7 +4156,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -4167,7 +4167,7 @@
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "react": {
@@ -4176,10 +4176,10 @@
       "integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
       }
     },
     "react-dom": {
@@ -4188,10 +4188,10 @@
       "integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
       }
     },
     "read-pkg": {
@@ -4200,9 +4200,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -4211,8 +4211,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -4221,8 +4221,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-exists": {
@@ -4231,7 +4231,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         }
       }
@@ -4242,13 +4242,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -4257,10 +4257,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "reason-react": {
@@ -4269,8 +4269,8 @@
       "integrity": "sha512-30SNLbpW8Ay0fB2nXb0H38ruv8I+WmznmnGze9C96+l3yEWa7/GccwwnenVLnye0t3o0j9Q9pC2E78oCw8tdDg==",
       "dev": true,
       "requires": {
-        "react": ">=15.0.0 || >=16.0.0",
-        "react-dom": ">=15.0.0 || >=16.0.0"
+        "react": "16.4.0",
+        "react-dom": "16.4.0"
       }
     },
     "regenerator-runtime": {
@@ -4285,7 +4285,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "remove-trailing-separator": {
@@ -4312,7 +4312,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "request": {
@@ -4321,28 +4321,28 @@
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
       }
     },
     "require-directory": {
@@ -4363,7 +4363,7 @@
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "right-align": {
@@ -4372,7 +4372,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -4381,7 +4381,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "ripemd160": {
@@ -4390,8 +4390,8 @@
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true,
       "requires": {
-        "hash-base": "^2.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "2.0.2",
+        "inherits": "2.0.3"
       }
     },
     "safe-buffer": {
@@ -4406,13 +4406,13 @@
       "integrity": "sha1-pK3q52TQSGIeyyfV+ez1ExAZOfM=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "exec-sh": "^0.2.0",
-        "fb-watchman": "^1.8.0",
-        "minimatch": "^3.0.2",
-        "minimist": "^1.1.1",
-        "walker": "~1.0.5",
-        "watch": "~0.10.0"
+        "anymatch": "1.3.2",
+        "exec-sh": "0.2.1",
+        "fb-watchman": "1.9.2",
+        "minimatch": "3.0.4",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.10.0"
       },
       "dependencies": {
         "bser": {
@@ -4421,7 +4421,7 @@
           "integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
           "dev": true,
           "requires": {
-            "node-int64": "^0.4.0"
+            "node-int64": "0.4.0"
           }
         },
         "fb-watchman": {
@@ -4476,8 +4476,8 @@
       "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "shebang-command": {
@@ -4486,7 +4486,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -4519,7 +4519,7 @@
       "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.0"
       }
     },
     "source-list-map": {
@@ -4540,7 +4540,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "spdx-correct": {
@@ -4549,7 +4549,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-license-ids": "1.2.2"
       }
     },
     "spdx-expression-parse": {
@@ -4576,14 +4576,14 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
     "stream-browserify": {
@@ -4592,8 +4592,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
       }
     },
     "stream-http": {
@@ -4602,11 +4602,11 @@
       "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.2.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
       }
     },
     "string-length": {
@@ -4615,7 +4615,7 @@
       "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
       "dev": true,
       "requires": {
-        "strip-ansi": "^3.0.0"
+        "strip-ansi": "3.0.1"
       }
     },
     "string-width": {
@@ -4624,9 +4624,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -4635,7 +4635,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -4650,7 +4650,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -4659,7 +4659,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-eof": {
@@ -4692,11 +4692,11 @@
       "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "micromatch": "^2.3.11",
-        "object-assign": "^4.1.0",
-        "read-pkg-up": "^1.0.1",
-        "require-main-filename": "^1.0.1"
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "require-main-filename": "1.0.1"
       }
     },
     "throat": {
@@ -4716,7 +4716,7 @@
       "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
       "dev": true,
       "requires": {
-        "setimmediate": "^1.0.4"
+        "setimmediate": "1.0.5"
       }
     },
     "tmpl": {
@@ -4743,7 +4743,7 @@
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "tr46": {
@@ -4770,7 +4770,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "tweetnacl": {
@@ -4786,7 +4786,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "ua-parser-js": {
@@ -4800,9 +4800,9 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "yargs": {
@@ -4811,9 +4811,9 @@
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -4832,9 +4832,9 @@
       "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.6",
-        "uglify-js": "^2.8.29",
-        "webpack-sources": "^1.0.1"
+        "source-map": "0.5.7",
+        "uglify-js": "2.8.29",
+        "webpack-sources": "1.0.1"
       }
     },
     "url": {
@@ -4890,8 +4890,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
       }
     },
     "verror": {
@@ -4900,9 +4900,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vm-browserify": {
@@ -4920,7 +4920,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.x"
+        "makeerror": "1.0.11"
       }
     },
     "watch": {
@@ -4935,9 +4935,9 @@
       "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
       "dev": true,
       "requires": {
-        "async": "^2.1.2",
-        "chokidar": "^1.7.0",
-        "graceful-fs": "^4.1.2"
+        "async": "2.5.0",
+        "chokidar": "1.7.0",
+        "graceful-fs": "4.1.11"
       }
     },
     "webidl-conversions": {
@@ -4952,28 +4952,28 @@
       "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.0",
-        "acorn-dynamic-import": "^2.0.0",
-        "ajv": "^5.1.5",
-        "ajv-keywords": "^2.0.0",
-        "async": "^2.1.2",
-        "enhanced-resolve": "^3.4.0",
-        "escope": "^3.6.0",
-        "interpret": "^1.0.0",
-        "json-loader": "^0.5.4",
-        "json5": "^0.5.1",
-        "loader-runner": "^2.3.0",
-        "loader-utils": "^1.1.0",
-        "memory-fs": "~0.4.1",
-        "mkdirp": "~0.5.0",
-        "node-libs-browser": "^2.0.0",
-        "source-map": "^0.5.3",
-        "supports-color": "^4.2.1",
-        "tapable": "^0.2.7",
-        "uglifyjs-webpack-plugin": "^0.4.6",
-        "watchpack": "^1.4.0",
-        "webpack-sources": "^1.0.1",
-        "yargs": "^8.0.2"
+        "acorn": "5.1.2",
+        "acorn-dynamic-import": "2.0.2",
+        "ajv": "5.2.3",
+        "ajv-keywords": "2.1.0",
+        "async": "2.5.0",
+        "enhanced-resolve": "3.4.1",
+        "escope": "3.6.0",
+        "interpret": "1.0.4",
+        "json-loader": "0.5.7",
+        "json5": "0.5.1",
+        "loader-runner": "2.3.0",
+        "loader-utils": "1.1.0",
+        "memory-fs": "0.4.1",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "2.0.0",
+        "source-map": "0.5.7",
+        "supports-color": "4.5.0",
+        "tapable": "0.2.8",
+        "uglifyjs-webpack-plugin": "0.4.6",
+        "watchpack": "1.4.0",
+        "webpack-sources": "1.0.1",
+        "yargs": "8.0.2"
       },
       "dependencies": {
         "acorn": {
@@ -5000,9 +5000,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
             "string-width": {
@@ -5011,9 +5011,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -5030,10 +5030,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
           }
         },
         "os-locale": {
@@ -5042,9 +5042,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "path-type": {
@@ -5053,7 +5053,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "^2.0.0"
+            "pify": "2.3.0"
           }
         },
         "read-pkg": {
@@ -5062,9 +5062,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
           }
         },
         "read-pkg-up": {
@@ -5073,8 +5073,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
           }
         },
         "string-width": {
@@ -5083,8 +5083,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -5099,7 +5099,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -5116,7 +5116,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         },
         "which-module": {
@@ -5131,19 +5131,19 @@
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
           }
         },
         "yargs-parser": {
@@ -5152,7 +5152,7 @@
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -5163,8 +5163,8 @@
       "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
       "dev": true,
       "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.5.3"
+        "source-list-map": "2.0.0",
+        "source-map": "0.5.7"
       }
     },
     "whatwg-encoding": {
@@ -5195,8 +5195,8 @@
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
       "dev": true,
       "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "tr46": "0.0.3",
+        "webidl-conversions": "3.0.1"
       },
       "dependencies": {
         "webidl-conversions": {
@@ -5213,7 +5213,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -5240,8 +5240,8 @@
       "integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
       "dev": true,
       "requires": {
-        "errno": "^0.1.4",
-        "xtend": "^4.0.1"
+        "errno": "0.1.4",
+        "xtend": "4.0.1"
       }
     },
     "wrap-ansi": {
@@ -5250,8 +5250,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -5290,19 +5290,19 @@
       "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^4.2.0"
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "4.2.1"
       },
       "dependencies": {
         "camelcase": {
@@ -5317,9 +5317,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         }
       }
@@ -5330,7 +5330,7 @@
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0"
+        "camelcase": "3.0.0"
       },
       "dependencies": {
         "camelcase": {

--- a/src/Css.re
+++ b/src/Css.re
@@ -116,9 +116,12 @@ type color = [
   | `hsl(int, int, int)
   | `hsla(int, int, int, float)
   | `hex(string)
+  | `colorVariable(string)
   | `transparent
   | `currentColor
 ];
+
+let string_of_css_var = s => "var(" ++ s ++ ")";
 
 let string_of_color =
   fun
@@ -162,6 +165,7 @@ let string_of_color =
        )
     ++ ")"
   | `hex(s) => "#" ++ s
+  | `colorVariable(s) => string_of_css_var(s)
   | `transparent => "transparent"
   | `currentColor => "currentColor";
 
@@ -383,6 +387,7 @@ type length = [
   | `vmax(float)
   | `vmin(float)
   | `vw(float)
+  | `lengthVariable(string)
   | `zero
 ];
 
@@ -407,6 +412,7 @@ let rec string_of_length =
   | `vmax(x) => string_of_float(x) ++ "vmax"
   | `vmin(x) => string_of_float(x) ++ "vmin"
   | `vw(x) => string_of_float(x) ++ "vw"
+  | `lengthVariable(s) => string_of_css_var(s)
   | `zero => "0";
 
 let ch = x => `ch(x);
@@ -629,6 +635,7 @@ let flexBasis = x =>
     | `vmax(x) => string_of_float(x) ++ "vmax"
     | `vmin(x) => string_of_float(x) ++ "vmin"
     | `vw(x) => string_of_float(x) ++ "vw"
+    | `lengthVariable(s) => string_of_css_var(s)
     | `zero => "0"
     | `fill => "fill"
     | `maxContent => "max-content"
@@ -681,6 +688,7 @@ let string_of_margin =
   | `vmin(x) => string_of_float(x) ++ "vmin"
   | `vw(x) => string_of_float(x) ++ "vw"
   | `zero => "0"
+  | `lengthVariable(s) => string_of_css_var(s)
   | `auto => "auto";
 
 let margin = x => d("margin", string_of_margin(x));
@@ -737,6 +745,7 @@ let string_of_dimension =
   | `vmin(x) => string_of_float(x) ++ "vmin"
   | `vw(x) => string_of_float(x) ++ "vw"
   | `fr(x) => string_of_float(x) ++ "fr"
+  | `lengthVariable(s) => string_of_css_var(s)
   | `zero => "0";
 let width = x => d("width", string_of_dimension(x));
 let maxWidth = x => d("maxWidth", string_of_dimension(x));
@@ -1052,6 +1061,7 @@ let background = x =>
          )
       ++ ")"
     | `hex(s) => "#" ++ s
+    | `colorVariable(s) => string_of_css_var(s)
     | `transparent => "transparent"
     | `currentColor => "currentColor"
     | `linearGradient(angle, stops) =>
@@ -1363,6 +1373,7 @@ let letterSpacing = x =>
     | `vmin(x) => string_of_float(x) ++ "vmin"
     | `vw(x) => string_of_float(x) ++ "vw"
     | `auto => "auto"
+    | `lengthVariable(s) => string_of_css_var(s)
     | `zero => "0"
     },
   );
@@ -1481,6 +1492,7 @@ let verticalAlign = x =>
     | `vmin(x) => string_of_float(x) ++ "vmin"
     | `vw(x) => string_of_float(x) ++ "vw"
     | `auto => "auto"
+    | `lengthVariable(s) => string_of_css_var(s)
     | `zero => "0"
     },
   );
@@ -1530,6 +1542,7 @@ let wordSpacing = x =>
     | `vmin(x) => string_of_float(x) ++ "vmin"
     | `vw(x) => string_of_float(x) ++ "vw"
     | `auto => "auto"
+    | `lengthVariable(s) => string_of_css_var(s)
     | `zero => "0"
     },
   );
@@ -1654,6 +1667,7 @@ let perspective = x =>
     | `vmax(x) => string_of_float(x) ++ "vmax"
     | `vmin(x) => string_of_float(x) ++ "vmin"
     | `vw(x) => string_of_float(x) ++ "vw"
+    | `lengthVariable(s) => string_of_css_var(s)
     | `zero => "0"
     },
   );
@@ -1895,3 +1909,13 @@ module SVG = {
   let stopColor = c => d("stopColor", string_of_color(c));
   let stopOpacity = o => d("stopOpacity", string_of_float(o));
 };
+
+/** Css Variables */
+let setCssVariable = (~name, value) =>
+  d(
+    name,
+    switch (value) {
+    | #color as x => string_of_color(x)
+    | #length as x => string_of_length(x)
+    },
+  );

--- a/src/Css.re
+++ b/src/Css.re
@@ -1,6 +1,6 @@
 let join = (separator, strings) => {
   let rec run = (acc, strings) =>
-    switch strings {
+    switch (strings) {
     | [] => acc
     | [x] => acc ++ x
     | [x, ...xs] => run(acc ++ x ++ separator, xs)
@@ -25,7 +25,7 @@ module Glamor = {
       ~fontFamily: string,
       ~src: string,
       ~fontStyle: string=?,
-      ~fontWeight: int=?,
+      ~fontWeight: int=?
     ) =>
     fontFace =
     "";
@@ -39,7 +39,7 @@ module Glamor = {
   ];
   let rec makeDict = ruleset => {
     let toJs = rule =>
-      switch rule {
+      switch (rule) {
       | `declaration(name, value) => (name, Js.Json.string(value))
       | `selector(name, ruleset) => (name, makeDict(ruleset))
       | `shadow(value) => ("boxShadow", Js.Json.string(value))
@@ -58,18 +58,19 @@ type rule = [
   | `animation(string)
   | `transition(string)
   | `shadow(string)
-  ];
+];
 type selector = [ | `selector(string, list(rule))];
 let empty = [];
 
 let merge = List.concat;
-let global = (selector, rules:list(rule)) => Glamor.makeGlobal(selector, Glamor.makeDict(rules));
+let global = (selector, rules: list(rule)) =>
+  Glamor.makeGlobal(selector, Glamor.makeDict(rules));
 
 type animation = string;
 
 let keyframes = frames => {
   let addStop = (dict, (stop, rules)) => {
-    Js.Dict.set(dict, (string_of_int(stop)++ "%"), Glamor.makeDict(rules));
+    Js.Dict.set(dict, string_of_int(stop) ++ "%", Glamor.makeDict(rules));
     dict;
   };
   Glamor.makeKeyFrames @@ List.fold_left(addStop, Js.Dict.empty(), frames);
@@ -77,31 +78,24 @@ let keyframes = frames => {
 
 let style = rules => rules |> Glamor.make |> Glamor.className;
 
-
 let d = (property, value) => `declaration((property, value));
 
 let func = (name, args) => name ++ "(" ++ join(", ", args) ++ ")";
 
 let string_of_float = (f: float) => {j|$(f)|j};
 
-let important = (v) =>
-  switch v {
-  | `declaration(name, value) => `declaration(name, value ++ " !important")
+let important = v =>
+  switch (v) {
+  | `declaration(name, value) => `declaration((name, value ++ " !important"))
   | _ => v
   };
 
-let label = (label) => `declaration("label", label);
-
+let label = label => `declaration(("label", label));
 
 /********************************************************
  ************************ VALUES ************************
  ********************************************************/
-type angle = [
-  | `deg(int)
-  | `rad(float)
-  | `grad(float)
-  | `turn(float)
-];
+type angle = [ | `deg(int) | `rad(float) | `grad(float) | `turn(float)];
 
 let string_of_angle =
   fun
@@ -128,10 +122,45 @@ type color = [
 
 let string_of_color =
   fun
-  | `rgb(r, g, b) => "rgb(" ++ join(", ", [string_of_int(r), string_of_int(g), string_of_int(b)]) ++ ")"
-  | `rgba(r, g, b, a) => "rgba(" ++ join( ", ", [ string_of_int(r), string_of_int(g), string_of_int(b), string_of_float(a) ]) ++ ")"
-  | `hsl(h, s, l) => "hsl(" ++ join(", ", [string_of_int(h), string_of_int(s) ++ "%", string_of_int(l) ++ "%"]) ++ ")"
-  | `hsla(h, s, l, a) => "hsla(" ++ join( ", ", [ string_of_int(h), string_of_int(s) ++ "%", string_of_int(l) ++ "%", string_of_float(a) ]) ++ ")"
+  | `rgb(r, g, b) =>
+    "rgb("
+    ++ join(", ", [string_of_int(r), string_of_int(g), string_of_int(b)])
+    ++ ")"
+  | `rgba(r, g, b, a) =>
+    "rgba("
+    ++ join(
+         ", ",
+         [
+           string_of_int(r),
+           string_of_int(g),
+           string_of_int(b),
+           string_of_float(a),
+         ],
+       )
+    ++ ")"
+  | `hsl(h, s, l) =>
+    "hsl("
+    ++ join(
+         ", ",
+         [
+           string_of_int(h),
+           string_of_int(s) ++ "%",
+           string_of_int(l) ++ "%",
+         ],
+       )
+    ++ ")"
+  | `hsla(h, s, l, a) =>
+    "hsla("
+    ++ join(
+         ", ",
+         [
+           string_of_int(h),
+           string_of_int(s) ++ "%",
+           string_of_int(l) ++ "%",
+           string_of_float(a),
+         ],
+       )
+    ++ ")"
   | `hex(s) => "#" ++ s
   | `transparent => "transparent"
   | `currentColor => "currentColor";
@@ -303,19 +332,34 @@ type gradient = [
 
 let string_of_stops = stops =>
   stops
-  |> List.map(((i, c)) => join(" ", [string_of_color(c), string_of_int(i) ++ "%"]))
+  |> List.map(((i, c)) =>
+       join(" ", [string_of_color(c), string_of_int(i) ++ "%"])
+     )
   |> join(", ");
 
 let string_of_gradient =
   fun
-  | `linearGradient(angle, stops) => "linear-gradient(" ++ string_of_angle(angle) ++ ", " ++ string_of_stops(stops) ++ ")"
-  | `repeatingLinearGradient(angle, stops) => "repeating-linear-gradient(" ++ string_of_angle(angle) ++ ", " ++ string_of_stops(stops) ++ ")"
-  | `radialGradient(stops) => "radial-gradient(" ++ string_of_stops(stops) ++ ")"
-  | `repeatingRadialGradient(stops) => "repeating-radial-gradient(" ++ string_of_stops(stops) ++ ")";
+  | `linearGradient(angle, stops) =>
+    "linear-gradient("
+    ++ string_of_angle(angle)
+    ++ ", "
+    ++ string_of_stops(stops)
+    ++ ")"
+  | `repeatingLinearGradient(angle, stops) =>
+    "repeating-linear-gradient("
+    ++ string_of_angle(angle)
+    ++ ", "
+    ++ string_of_stops(stops)
+    ++ ")"
+  | `radialGradient(stops) =>
+    "radial-gradient(" ++ string_of_stops(stops) ++ ")"
+  | `repeatingRadialGradient(stops) =>
+    "repeating-radial-gradient(" ++ string_of_stops(stops) ++ ")";
 
 let linearGradient = (angle, stops) => `linearGradient((angle, stops));
 
-let repeatingLinearGradient = (angle, stops) => `repeatingLinearGradient((angle, stops));
+let repeatingLinearGradient = (angle, stops) =>
+  `repeatingLinearGradient((angle, stops));
 
 let radialGradient = stops => `radialGradient(stops);
 
@@ -325,7 +369,7 @@ let repeatingRadialGradient = stops => `repeatingRadialGradient(stops);
  * Units
  */
 type length = [
-  | `calc([ |`add | `sub], length, length)
+  | `calc([ | `add | `sub], length, length)
   | `ch(float)
   | `cm(float)
   | `em(float)
@@ -342,14 +386,14 @@ type length = [
   | `zero
 ];
 
-type gridLength = [
-  length | `fr(float)
-];
+type gridLength = [ length | `fr(float)];
 
 let rec string_of_length =
   fun
-  | `calc(`add, a, b) => "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
-  | `calc(`sub, a, b) => "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
+  | `calc(`add, a, b) =>
+    "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
+  | `calc(`sub, a, b) =>
+    "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
   | `ch(x) => string_of_float(x) ++ "ch"
   | `cm(x) => string_of_float(x) ++ "cm"
   | `em(x) => string_of_float(x) ++ "em"
@@ -364,7 +408,6 @@ let rec string_of_length =
   | `vmin(x) => string_of_float(x) ++ "vmin"
   | `vw(x) => string_of_float(x) ++ "vw"
   | `zero => "0";
-
 
 let ch = x => `ch(x);
 let cm = x => `cm(x);
@@ -382,10 +425,9 @@ let vmin = x => `vmin(x);
 let vw = x => `vw(x);
 let zero = `zero;
 
-
 module Calc = {
-  let (-) = (a, b) => `calc(`sub, a, b);
-  let (+) = (a, b) => `calc(`add, a, b);
+  let (-) = (a, b) => `calc((`sub, a, b));
+  let (+) = (a, b) => `calc((`add, a, b));
 };
 let size = (x, y) => `size((x, y));
 
@@ -406,9 +448,9 @@ let column = `column;
 let columnReverse = `columnReverse;
 let contain = `contain;
 let contentBox = `contentBox;
-let count = x =>  `count(x);
+let count = x => `count(x);
 let cover = `cover;
-let cubicBesier = (a, b, c, d) => `cubicBezier(a, b, c, d);
+let cubicBesier = (a, b, c, d) => `cubicBezier((a, b, c, d));
 let dashed = `dashed;
 let dotted = `dotted;
 let ease = `ease;
@@ -439,38 +481,38 @@ let relative = `relative;
 let repeat = `repeat;
 let repeatX = `repeatX;
 let repeatY = `repeatY;
-let rotate = (a) => `rotate(a);
-let rotate3d = (x, y, z, a) => `rotate3d(x, y, z, a);
-let rotateX = (a) => `rotateX(a);
-let rotateY = (a) => `rotateY(a);
-let rotateZ = (a) => `rotateZ(a);
+let rotate = a => `rotate(a);
+let rotate3d = (x, y, z, a) => `rotate3d((x, y, z, a));
+let rotateX = a => `rotateX(a);
+let rotateY = a => `rotateY(a);
+let rotateZ = a => `rotateZ(a);
 let row = `row;
 let rowReverse = `rowReverse;
 let running = `running;
-let scale = (x, y) => `scale(x, y);
-let scale3d = (x, y, z) => `scale3d(x, y, z);
-let scaleX = (x) => `scaleX(x);
-let scaleY = (x) => `scaleY(x);
+let scale = (x, y) => `scale((x, y));
+let scale3d = (x, y, z) => `scale3d((x, y, z));
+let scaleX = x => `scaleX(x);
+let scaleY = x => `scaleY(x);
 let scaleZ = x => `scaleZ(x);
 let scroll = `scroll;
-let skew = (x, y) => `skew(x, y);
-let skewX = (a) => `skewX(a);
-let skewY = (a) => `skewY(a);
+let skew = (x, y) => `skew((x, y));
+let skewX = a => `skewX(a);
+let skewY = a => `skewY(a);
 let solid = `solid;
 let spaceAround = `spaceAround;
 let spaceBetween = `spaceBetween;
 let static = `static;
 let stepEnd = `stepEnd;
-let steps = (i, dir) => `steps(i, dir);
+let steps = (i, dir) => `steps((i, dir));
 let stepStart = `stepStart;
 let sticky = `sticky;
 let stretch = `stretch;
 let text = `text;
-let translate  = (x, y) => `translate(x, y);
-let translate3d = (x, y, z) => `translate3d(x, y, z);
-let translateX = (x) => `translateX(x);
-let translateY = (y) => `translateY(y);
-let translateZ = (z) => `translateZ(z);
+let translate = (x, y) => `translate((x, y));
+let translate3d = (x, y, z) => `translate3d((x, y, z));
+let translateX = x => `translateX(x);
+let translateY = y => `translateY(y);
+let translateZ = z => `translateZ(z);
 let url = x => `url(x);
 let visible = `visible;
 let wrap = `wrap;
@@ -482,13 +524,11 @@ let outside = `outside;
 let italic = `italic;
 let oblique = `oblique;
 
-
 let underline = `underline;
 let overline = `overline;
 let lineThrough = `lineThough;
 let clip = `clip;
 let ellipsis = `ellipsis;
-
 
 let wavy = `wavy;
 let double = `double;
@@ -497,10 +537,9 @@ let uppercase = `uppercase;
 let lowercase = `lowercase;
 let capitalize = `capitalize;
 
-
 let sub = `sub;
 let super = `super;
-let textTop= `textTop;
+let textTop = `textTop;
 let textBottom = `textBottom;
 let middle = `middle;
 
@@ -514,13 +553,11 @@ let reverse = `reverse;
 let alternate = `alternate;
 let alternateReverse = `alternateReverse;
 
-
 let fill = `fill;
 let content = `content;
 let maxContent = `maxContent;
 let minContent = `minContent;
 let fitContent = `fitContent;
-
 
 let round = `round;
 let miter = `miter;
@@ -532,12 +569,14 @@ let square = `square;
  ******************** PROPERTIES ************************
  ********************************************************/
 
- let unsafe = d;
+let unsafe = d;
 /**
  * Layout
  **/
 let display = x =>
-  d( "display", switch x {
+  d(
+    "display",
+    switch (x) {
     | `block => "block"
     | `inline => "inline"
     | `inlineBlock => "inline-block"
@@ -546,16 +585,20 @@ let display = x =>
     | `inlineFlex => "inline-flex"
     | `grid => "grid"
     | `inlineGrid => "inline-grid"
-    });
+    },
+  );
 
 let position = x =>
-  d( "position", switch x {
+  d(
+    "position",
+    switch (x) {
     | `absolute => "absolute"
     | `static => "static"
     | `fixed => "fixed"
     | `relative => "relative"
     | `sticky => "sticky"
-  });
+    },
+  );
 
 let top = x => d("top", string_of_length(x));
 let bottom = x => d("bottom", string_of_length(x));
@@ -565,51 +608,65 @@ let right = x => d("right", string_of_length(x));
 let flex = x => d("flex", string_of_int(x));
 let flexGrow = x => d("flexGrow", string_of_int(x));
 let flexShrink = x => d("flexShrink", string_of_int(x));
-let flexBasis = x => d("flexBasis", switch x {
-  | `calc(`add, a, b) => "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
-  | `calc(`sub, a, b) => "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
-  | `ch(x) => string_of_float(x) ++ "ch"
-  | `cm(x) => string_of_float(x) ++ "cm"
-  | `em(x) => string_of_float(x) ++ "em"
-  | `ex(x) => string_of_float(x) ++ "ex"
-  | `mm(x) => string_of_float(x) ++ "mm"
-  | `percent(x) => string_of_float(x) ++ "%"
-  | `pt(x) => string_of_int(x) ++ "pt"
-  | `px(x) => string_of_int(x) ++ "px"
-  | `rem(x) => string_of_float(x) ++ "rem"
-  | `vh(x) => string_of_float(x) ++ "vh"
-  | `vmax(x) => string_of_float(x) ++ "vmax"
-  | `vmin(x) => string_of_float(x) ++ "vmin"
-  | `vw(x) => string_of_float(x) ++ "vw"
-  | `zero => "0"
-  | `fill => "fill"
-  | `maxContent => "max-content"
-  | `minContent => "min-content"
-  | `fitContent => "fit-content"
-  | `content => "content"
-  | `auto => "auto"
-});
+let flexBasis = x =>
+  d(
+    "flexBasis",
+    switch (x) {
+    | `calc(`add, a, b) =>
+      "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
+    | `calc(`sub, a, b) =>
+      "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
+    | `ch(x) => string_of_float(x) ++ "ch"
+    | `cm(x) => string_of_float(x) ++ "cm"
+    | `em(x) => string_of_float(x) ++ "em"
+    | `ex(x) => string_of_float(x) ++ "ex"
+    | `mm(x) => string_of_float(x) ++ "mm"
+    | `percent(x) => string_of_float(x) ++ "%"
+    | `pt(x) => string_of_int(x) ++ "pt"
+    | `px(x) => string_of_int(x) ++ "px"
+    | `rem(x) => string_of_float(x) ++ "rem"
+    | `vh(x) => string_of_float(x) ++ "vh"
+    | `vmax(x) => string_of_float(x) ++ "vmax"
+    | `vmin(x) => string_of_float(x) ++ "vmin"
+    | `vw(x) => string_of_float(x) ++ "vw"
+    | `zero => "0"
+    | `fill => "fill"
+    | `maxContent => "max-content"
+    | `minContent => "min-content"
+    | `fitContent => "fit-content"
+    | `content => "content"
+    | `auto => "auto"
+    },
+  );
 let flexDirection = x =>
-  d( "flexDirection", switch x {
+  d(
+    "flexDirection",
+    switch (x) {
     | `row => "row"
     | `column => "column"
     | `rowReverse => "row-reverse"
     | `columnReverse => "column-reverse"
-    });
+    },
+  );
 
 let flexWrap = x =>
-  d( "flexWrap", switch x {
+  d(
+    "flexWrap",
+    switch (x) {
     | `nowrap => "nowrap"
     | `wrap => "wrap"
     | `wrapReverse => "wrap-reverse"
-    });
+    },
+  );
 
 let order = x => d("order", string_of_int(x));
 
 let string_of_margin =
   fun
-  | `calc(`add, a, b) => "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
-  | `calc(`sub, a, b) => "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
+  | `calc(`add, a, b) =>
+    "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
+  | `calc(`sub, a, b) =>
+    "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
   | `ch(x) => string_of_float(x) ++ "ch"
   | `cm(x) => string_of_float(x) ++ "cm"
   | `em(x) => string_of_float(x) ++ "em"
@@ -627,28 +684,45 @@ let string_of_margin =
   | `auto => "auto";
 
 let margin = x => d("margin", string_of_margin(x));
-let margin2 = (~v, ~h) => d("margin", [v, h] |> List.map(string_of_margin) |> join(" "));
-let margin3 = (~top, ~h, ~bottom) => d("margin", [top, h, bottom] |> List.map(string_of_margin) |> join(" "));
-let margin4 = (~top, ~right, ~bottom, ~left) => d("margin", [top, right, bottom, left] |> List.map(string_of_margin) |> join(" "));
+let margin2 = (~v, ~h) =>
+  d("margin", [v, h] |> List.map(string_of_margin) |> join(" "));
+let margin3 = (~top, ~h, ~bottom) =>
+  d("margin", [top, h, bottom] |> List.map(string_of_margin) |> join(" "));
+let margin4 = (~top, ~right, ~bottom, ~left) =>
+  d(
+    "margin",
+    [top, right, bottom, left] |> List.map(string_of_margin) |> join(" "),
+  );
 let marginLeft = x => d("marginLeft", string_of_margin(x));
 let marginRight = x => d("marginRight", string_of_margin(x));
 let marginTop = x => d("marginTop", string_of_margin(x));
 let marginBottom = x => d("marginBottom", string_of_margin(x));
 
 let padding = x => d("padding", string_of_length(x));
-let padding2 = (~v, ~h) => d("padding", [v, h] |> List.map(string_of_length) |> join(" "));
-let padding3 = (~top, ~h, ~bottom) => d("padding", [top, h, bottom] |> List.map(string_of_length) |> join(" "));
-let padding4 = (~top, ~right, ~bottom, ~left) => d("padding", [top, right, bottom, left] |> List.map(string_of_length) |> join(" "));
+let padding2 = (~v, ~h) =>
+  d("padding", [v, h] |> List.map(string_of_length) |> join(" "));
+let padding3 = (~top, ~h, ~bottom) =>
+  d(
+    "padding",
+    [top, h, bottom] |> List.map(string_of_length) |> join(" "),
+  );
+let padding4 = (~top, ~right, ~bottom, ~left) =>
+  d(
+    "padding",
+    [top, right, bottom, left] |> List.map(string_of_length) |> join(" "),
+  );
 let paddingLeft = x => d("paddingLeft", string_of_length(x));
 let paddingRight = x => d("paddingRight", string_of_length(x));
 let paddingTop = x => d("paddingTop", string_of_length(x));
 let paddingBottom = x => d("paddingBottom", string_of_length(x));
 
-
-let string_of_dimension = fun
+let string_of_dimension =
+  fun
   | `auto => "auto"
-  | `calc(`add, a, b) => "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
-  | `calc(`sub, a, b) => "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
+  | `calc(`add, a, b) =>
+    "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
+  | `calc(`sub, a, b) =>
+    "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
   | `ch(x) => string_of_float(x) ++ "ch"
   | `cm(x) => string_of_float(x) ++ "cm"
   | `em(x) => string_of_float(x) ++ "em"
@@ -672,9 +746,7 @@ let minHeight = x => d("minHeight", string_of_dimension(x));
 let maxHeight = x => d("maxHeight", string_of_dimension(x));
 
 let string_of_dimensions = dimensions =>
-  dimensions
-  |> List.map(string_of_dimension)
-  |> String.concat(" ");
+  dimensions |> List.map(string_of_dimension) |> String.concat(" ");
 
 let gridTemplateColumns = dimensions =>
   d("gridTemplateColumns", string_of_dimensions(dimensions));
@@ -685,31 +757,24 @@ let gridTemplateRows = dimensions =>
 let gridAutoRows = dimensions =>
   d("gridAutoRows", string_of_dimension(dimensions));
 
+let gridColumn = (start, end') =>
+  d("gridColumn", string_of_int(start) ++ " / " ++ string_of_int(end'));
 
-let gridColumn = (start, end') => d("gridColumn", string_of_int(start) ++ " / " ++ string_of_int(end'));
+let gridRow = (start, end') =>
+  d("gridRow", string_of_int(start) ++ " / " ++ string_of_int(end'));
+let gridColumnStart = n => d("gridColumnStart", string_of_int(n));
 
-let gridRow = (start, end') => d("gridRow", string_of_int(start) ++ " / " ++ string_of_int(end'));
-let gridColumnStart = n =>
-  d("gridColumnStart", string_of_int(n));
+let gridColumnEnd = n => d("gridColumnEnd", string_of_int(n));
 
-let gridColumnEnd = n =>
-  d("gridColumnEnd", string_of_int(n));
+let gridRowStart = n => d("gridRowStart", string_of_int(n));
 
-let gridRowStart = n =>
-  d("gridRowStart", string_of_int(n));
+let gridRowEnd = n => d("gridRowEnd", string_of_int(n));
 
-let gridRowEnd = n =>
-  d("gridRowEnd", string_of_int(n));
+let gridColumnGap = n => d("gridColumnGap", string_of_length(n));
 
-let gridColumnGap = n =>
-  d("gridColumnGap", string_of_length(n));
+let gridRowGap = n => d("gridRowGap", string_of_length(n));
 
-let gridRowGap = n =>
-  d("gridRowGap", string_of_length(n));
-
-let gridGap = n =>
-  d("gridGap", string_of_length(n));
-
+let gridGap = n => d("gridGap", string_of_length(n));
 
 let string_of_align =
   fun
@@ -734,24 +799,33 @@ let justifyContent = x => d("justifyContent", string_of_justify(x));
 let alignContent = x => d("alignContent", string_of_justify(x));
 
 let boxSizing = x =>
-  d( "boxSizing", switch x {
+  d(
+    "boxSizing",
+    switch (x) {
     | `contentBox => "content-box"
     | `borderBox => "border-box"
-    });
+    },
+  );
 
 let float = x =>
-  d( "float", switch x {
+  d(
+    "float",
+    switch (x) {
     | `left => "left"
     | `right => "right"
     | `none => "none"
-    });
+    },
+  );
 
 let clear = x =>
-  d( "clear", switch x {
+  d(
+    "clear",
+    switch (x) {
     | `left => "left"
     | `right => "right"
     | `both => "both"
-  });
+    },
+  );
 
 let string_of_overflow =
   fun
@@ -772,30 +846,44 @@ let zIndex = i => d("zIndex", string_of_int(i));
  * Style
 **/
 let backfaceVisibility = x =>
-  d( "backfaceVisibility", switch x {
+  d(
+    "backfaceVisibility",
+    switch (x) {
     | `hidden => "hidden"
     | `visible => "visible"
-  });
+    },
+  );
 
 let visibility = x =>
-  d( "visibility", switch x {
+  d(
+    "visibility",
+    switch (x) {
     | `hidden => "hidden"
     | `visible => "visible"
-  });
+    },
+  );
 
-let boxShadow = (~x=zero, ~y=zero, ~blur=zero, ~spread=zero, ~inset=false, color) =>
-  `shadow(join( " ", [
-    string_of_length(x),
-    string_of_length(y),
-    string_of_length(blur),
-    string_of_length(spread),
-    string_of_color(color),
-    inset ? "inset" : "",
-  ]));
+let boxShadow =
+    (~x=zero, ~y=zero, ~blur=zero, ~spread=zero, ~inset=false, color) =>
+  `shadow(
+    join(
+      " ",
+      [
+        string_of_length(x),
+        string_of_length(y),
+        string_of_length(blur),
+        string_of_length(spread),
+        string_of_color(color),
+        inset ? "inset" : "",
+      ],
+    ),
+  );
 
-let string_of_shadow = fun
-| `shadow(s) => s;
-let boxShadows = shadows => d("boxShadow", shadows |> List.map(string_of_shadow) |> join(", "));
+let string_of_shadow =
+  fun
+  | `shadow(s) => s;
+let boxShadows = shadows =>
+  d("boxShadow", shadows |> List.map(string_of_shadow) |> join(", "));
 
 let string_of_borderstyle =
   fun
@@ -805,71 +893,109 @@ let string_of_borderstyle =
   | `none => "none";
 
 let border = (px, style, color) =>
-  d( "border", join( " ", [
-    string_of_length(px),
-    string_of_borderstyle(style),
-    string_of_color(color)
-  ]));
+  d(
+    "border",
+    join(
+      " ",
+      [
+        string_of_length(px),
+        string_of_borderstyle(style),
+        string_of_color(color),
+      ],
+    ),
+  );
 let borderWidth = x => d("borderWidth", string_of_length(x));
 let borderStyle = x => d("borderStyle", string_of_borderstyle(x));
 let borderColor = x => d("borderColor", string_of_color(x));
 
 let borderLeft = (px, style, color) =>
-  d( "borderLeft", join( " ", [
-    string_of_length(px),
-    string_of_borderstyle(style),
-    string_of_color(color)
-  ]));
+  d(
+    "borderLeft",
+    join(
+      " ",
+      [
+        string_of_length(px),
+        string_of_borderstyle(style),
+        string_of_color(color),
+      ],
+    ),
+  );
 let borderLeftWidth = x => d("borderLeftWidth", string_of_length(x));
 let borderLeftStyle = x => d("borderLeftStyle", string_of_borderstyle(x));
 let borderLeftColor = x => d("borderLeftColor", string_of_color(x));
 
 let borderRight = (px, style, color) =>
-  d( "borderRight", join( " ", [
-    string_of_length(px),
-    string_of_borderstyle(style),
-    string_of_color(color)
-    ]));
+  d(
+    "borderRight",
+    join(
+      " ",
+      [
+        string_of_length(px),
+        string_of_borderstyle(style),
+        string_of_color(color),
+      ],
+    ),
+  );
 
 let borderRightWidth = x => d("borderRightWidth", string_of_length(x));
 let borderRightColor = x => d("borderRightColor", string_of_color(x));
 let borderRightStyle = x => d("borderRightStyle", string_of_borderstyle(x));
 let borderTop = (px, style, color) =>
-  d( "borderTop", join( " ", [
-      string_of_length(px),
-      string_of_borderstyle(style),
-      string_of_color(color)
-    ]));
+  d(
+    "borderTop",
+    join(
+      " ",
+      [
+        string_of_length(px),
+        string_of_borderstyle(style),
+        string_of_color(color),
+      ],
+    ),
+  );
 
 let borderTopWidth = x => d("borderTopWidth", string_of_length(x));
 let borderTopStyle = x => d("borderTopStyle", string_of_borderstyle(x));
 let borderTopColor = x => d("borderTopColor", string_of_color(x));
 
 let borderBottom = (px, style, color) =>
-  d( "borderBottom", join( " ", [
-    string_of_length(px),
-    string_of_borderstyle(style),
-    string_of_color(color)
-  ]));
+  d(
+    "borderBottom",
+    join(
+      " ",
+      [
+        string_of_length(px),
+        string_of_borderstyle(style),
+        string_of_color(color),
+      ],
+    ),
+  );
 let borderBottomWidth = x => d("borderBottomWidth", string_of_length(x));
-let borderBottomStyle = x => d("borderBottomStyle", string_of_borderstyle(x));
+let borderBottomStyle = x =>
+  d("borderBottomStyle", string_of_borderstyle(x));
 let borderBottomColor = x => d("borderBottomColor", string_of_color(x));
 
 let borderRadius = i => d("borderRadius", string_of_length(i));
 let borderTopLeftRadius = i => d("borderTopLeftRadius", string_of_length(i));
-let borderTopRightRadius = i => d("borderTopRightRadius", string_of_length(i));
-let borderBottomLeftRadius = i => d("borderBottomLeftRadius", string_of_length(i));
-let borderBottomRightRadius = i => d("borderBottomRightRadius", string_of_length(i));
+let borderTopRightRadius = i =>
+  d("borderTopRightRadius", string_of_length(i));
+let borderBottomLeftRadius = i =>
+  d("borderBottomLeftRadius", string_of_length(i));
+let borderBottomRightRadius = i =>
+  d("borderBottomRightRadius", string_of_length(i));
 
 let tableLayout = x =>
-  d("tableLayout", switch x {
+  d(
+    "tableLayout",
+    switch (x) {
     | `auto => "auto"
     | `fixed => "fixed"
     },
   );
 
 let borderCollapse = x =>
-  d("borderCollapse", switch x {
+  d(
+    "borderCollapse",
+    switch (x) {
     | `collapse => "collapse"
     | `separate => "separate"
     },
@@ -878,74 +1004,162 @@ let borderCollapse = x =>
 let borderSpacing = i => d("borderSpacing", string_of_length(i));
 
 let background = x =>
-  d( "background", switch x {
+  d(
+    "background",
+    switch (x) {
     | `none => "none"
     | `url(url) => "url(" ++ url ++ ")"
-    | `rgb(r, g, b) => "rgb(" ++ join(", ", [string_of_int(r), string_of_int(g), string_of_int(b)]) ++ ")"
-    | `rgba(r, g, b, a) => "rgba(" ++ join( ", ", [ string_of_int(r), string_of_int(g), string_of_int(b), string_of_float(a) ]) ++ ")"
-    | `hsl(h, s, l) => "hsl(" ++ join(", ", [string_of_int(h), string_of_int(s) ++ "%", string_of_int(l) ++ "%"]) ++ ")"
-    | `hsla(h, s, l, a) => "hsla(" ++ join( ", ", [ string_of_int(h), string_of_int(s) ++ "%", string_of_int(l) ++ "%", string_of_float(a) ]) ++ ")"
+    | `rgb(r, g, b) =>
+      "rgb("
+      ++ join(
+           ", ",
+           [string_of_int(r), string_of_int(g), string_of_int(b)],
+         )
+      ++ ")"
+    | `rgba(r, g, b, a) =>
+      "rgba("
+      ++ join(
+           ", ",
+           [
+             string_of_int(r),
+             string_of_int(g),
+             string_of_int(b),
+             string_of_float(a),
+           ],
+         )
+      ++ ")"
+    | `hsl(h, s, l) =>
+      "hsl("
+      ++ join(
+           ", ",
+           [
+             string_of_int(h),
+             string_of_int(s) ++ "%",
+             string_of_int(l) ++ "%",
+           ],
+         )
+      ++ ")"
+    | `hsla(h, s, l, a) =>
+      "hsla("
+      ++ join(
+           ", ",
+           [
+             string_of_int(h),
+             string_of_int(s) ++ "%",
+             string_of_int(l) ++ "%",
+             string_of_float(a),
+           ],
+         )
+      ++ ")"
     | `hex(s) => "#" ++ s
     | `transparent => "transparent"
     | `currentColor => "currentColor"
-    | `linearGradient(angle, stops) => "linear-gradient(" ++ string_of_angle(angle) ++ ", " ++ string_of_stops(stops) ++ ")"
-    | `repeatingLinearGradient(angle, stops) => "repeating-linear-gradient(" ++ string_of_angle(angle) ++ ", " ++ string_of_stops(stops) ++ ")"
-    | `radialGradient(stops) => "radial-gradient(" ++ string_of_stops(stops) ++ ")"
-    | `repeatingRadialGradient(stops) => "repeating-radial-gradient(" ++ string_of_stops(stops) ++ ")"
-  });
+    | `linearGradient(angle, stops) =>
+      "linear-gradient("
+      ++ string_of_angle(angle)
+      ++ ", "
+      ++ string_of_stops(stops)
+      ++ ")"
+    | `repeatingLinearGradient(angle, stops) =>
+      "repeating-linear-gradient("
+      ++ string_of_angle(angle)
+      ++ ", "
+      ++ string_of_stops(stops)
+      ++ ")"
+    | `radialGradient(stops) =>
+      "radial-gradient(" ++ string_of_stops(stops) ++ ")"
+    | `repeatingRadialGradient(stops) =>
+      "repeating-radial-gradient(" ++ string_of_stops(stops) ++ ")"
+    },
+  );
 let backgroundColor = x => d("backgroundColor", string_of_color(x));
 let backgroundImage = x =>
-  d( "backgroundImage", switch x {
+  d(
+    "backgroundImage",
+    switch (x) {
     | `none => "none"
     | `url(url) => "url(" ++ url ++ ")"
-    | `linearGradient(angle, stops) => "linear-gradient(" ++ string_of_angle(angle) ++ ", " ++ string_of_stops(stops) ++ ")"
-    | `repeatingLinearGradient(angle, stops) => "repeating-linear-gradient(" ++ string_of_angle(angle) ++ ", " ++ string_of_stops(stops) ++ ")"
-    | `radialGradient(stops) => "radial-gradient(" ++ string_of_stops(stops) ++ ")"
-    | `repeatingRadialGradient(stops) => "repeating-radial-gradient(" ++ string_of_stops(stops) ++ ")"
-  });
+    | `linearGradient(angle, stops) =>
+      "linear-gradient("
+      ++ string_of_angle(angle)
+      ++ ", "
+      ++ string_of_stops(stops)
+      ++ ")"
+    | `repeatingLinearGradient(angle, stops) =>
+      "repeating-linear-gradient("
+      ++ string_of_angle(angle)
+      ++ ", "
+      ++ string_of_stops(stops)
+      ++ ")"
+    | `radialGradient(stops) =>
+      "radial-gradient(" ++ string_of_stops(stops) ++ ")"
+    | `repeatingRadialGradient(stops) =>
+      "repeating-radial-gradient(" ++ string_of_stops(stops) ++ ")"
+    },
+  );
 
 let backgroundAttachment = x =>
-  d( "backgroundAttachment", switch x {
+  d(
+    "backgroundAttachment",
+    switch (x) {
     | `scroll => "scroll"
     | `fixed => "fixed"
     | `local => "local"
-  });
+    },
+  );
 
 let backgroundClip = x =>
-  d( "backgroundClip", switch x {
+  d(
+    "backgroundClip",
+    switch (x) {
     | `borderBox => "border-box"
     | `contentBox => "content-box"
     | `paddingBox => "padding-box"
-  });
+    },
+  );
 
 let backgroundOrigin = x =>
-  d( "backgroundOrigin", switch x {
+  d(
+    "backgroundOrigin",
+    switch (x) {
     | `borderBox => "border-box"
     | `contentBox => "content-box"
     | `paddingBox => "padding-box"
-  });
+    },
+  );
 
 let backgroundPosition = (x, y) =>
-  d("backgroundPosition", string_of_length(x) ++ " " ++ string_of_length(y));
+  d(
+    "backgroundPosition",
+    string_of_length(x) ++ " " ++ string_of_length(y),
+  );
 
 let backgroundRepeat = x =>
-  d( "backgroundRepeat", switch x {
+  d(
+    "backgroundRepeat",
+    switch (x) {
     | `repeat => "repeat"
     | `noRepeat => "no-repeat"
     | `repeatX => "repeat-x"
     | `repeatY => "repeat-y"
-  });
+    },
+  );
 
 let backgroundSize = x =>
-  d( "backgroundSize", switch x {
+  d(
+    "backgroundSize",
+    switch (x) {
     | `size(x, y) => string_of_length(x) ++ " " ++ string_of_length(y)
     | `auto => "auto"
     | `cover => "cover"
     | `contain => "contain"
-  });
+    },
+  );
 
 let cursor = x =>
-  d( "cursor", switch x {
+  d(
+    "cursor",
+    switch (x) {
     | `pointer => "pointer"
     | `alias => "alias"
     | `allScroll => "all-scroll"
@@ -966,12 +1180,16 @@ let cursor = x =>
     | `wait => "wait"
     | `zoomIn => "zoom-in"
     | `zoomOut => "zoom-out"
-    });
+    },
+  );
 
 let clipPath = x =>
-  d( "clipPath", switch x {
+  d(
+    "clipPath",
+    switch (x) {
     | `url(url) => "url(" ++ url ++ ")"
-    });
+    },
+  );
 
 type listStyleType = [
   | `disc
@@ -1014,7 +1232,15 @@ let stirng_of_listStyleImage =
   | `url(url) => func("url", [url]);
 
 let listStyle = (style, pos, img) =>
-  d( "listStyle", [ string_of_listStyleType(style), string_of_listStylePosition(pos), stirng_of_listStyleImage(img) ] |> join(" "));
+  d(
+    "listStyle",
+    [
+      string_of_listStyleType(style),
+      string_of_listStylePosition(pos),
+      stirng_of_listStyleImage(img),
+    ]
+    |> join(" "),
+  );
 
 let listStyleType = x => d("listStyleType", string_of_listStyleType(x));
 
@@ -1052,7 +1278,15 @@ let string_of_outlineStyle =
   | `outset => "outset";
 
 let outline = (size, style, color) =>
-  d( "outline", [ string_of_length(size), string_of_outlineStyle(style), string_of_color(color) ] |> join(" "));
+  d(
+    "outline",
+    [
+      string_of_length(size),
+      string_of_outlineStyle(style),
+      string_of_color(color),
+    ]
+    |> join(" "),
+  );
 
 let outlineStyle = x => d("outlineStyle", string_of_outlineStyle(x));
 
@@ -1075,17 +1309,20 @@ let fontFamily = x => d("fontFamily", x);
 
 let fontSize = x => d("fontSize", string_of_length(x));
 
-let fontVariant = x => d("fontVariant", switch x {
-| `normal => "normal"
-| `smallCaps => "small-caps"
-});
+let fontVariant = x =>
+  d(
+    "fontVariant",
+    switch (x) {
+    | `normal => "normal"
+    | `smallCaps => "small-caps"
+    },
+  );
 
-let fontStyle = x =>
-  d("fontStyle", fontStyleToJs(x));
+let fontStyle = x => d("fontStyle", fontStyleToJs(x));
 
-let fontFace =
-    (~fontFamily, ~src, ~fontStyle=?, ~fontWeight=?, ()) => {
-  let fontStyle = Js.Option.map((. value) => fontStyleToJs(value), fontStyle);
+let fontFace = (~fontFamily, ~src, ~fontStyle=?, ~fontWeight=?, ()) => {
+  let fontStyle =
+    Js.Option.map((. value) => fontStyleToJs(value), fontStyle);
   let src =
     src
     |> List.map(
@@ -1095,9 +1332,7 @@ let fontFace =
        )
     |> String.concat(", ");
   Glamor.(
-    makeFontFace(
-      fontFace(~fontFamily, ~src, ~fontStyle?, ~fontWeight?),
-    )
+    makeFontFace(fontFace(~fontFamily, ~src, ~fontStyle?, ~fontWeight?))
   );
 };
 
@@ -1106,10 +1341,14 @@ let fontWeight = x => d("fontWeight", string_of_int(x));
 let lineHeight = x => d("lineHeight", string_of_float(x));
 
 let letterSpacing = x =>
-  d( "letterSpacing", switch x {
+  d(
+    "letterSpacing",
+    switch (x) {
     | `normal => "normal"
-    | `calc(`add, a, b) => "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
-    | `calc(`sub, a, b) => "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
+    | `calc(`add, a, b) =>
+      "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
+    | `calc(`sub, a, b) =>
+      "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
     | `ch(x) => string_of_float(x) ++ "ch"
     | `cm(x) => string_of_float(x) ++ "cm"
     | `em(x) => string_of_float(x) ++ "em"
@@ -1125,70 +1364,97 @@ let letterSpacing = x =>
     | `vw(x) => string_of_float(x) ++ "vw"
     | `auto => "auto"
     | `zero => "0"
-  });
+    },
+  );
 
 let textAlign = x =>
-  d( "textAlign", switch x {
+  d(
+    "textAlign",
+    switch (x) {
     | `left => "left"
     | `right => "right"
     | `center => "center"
     | `justify => "justify"
-  });
+    },
+  );
 
 let textDecoration = x =>
-  d( "textDecoration", switch x {
+  d(
+    "textDecoration",
+    switch (x) {
     | `none => "none"
     | `underline => "underline"
     | `overline => "overline"
     | `lineThrough => "line-through"
-  });
+    },
+  );
 
 let textDecorationColor = x => d("textDecorationColor", string_of_color(x));
 
 let textDecorationStyle = x =>
-  d( "textDecorationStyle", switch x {
+  d(
+    "textDecorationStyle",
+    switch (x) {
     | `wavy => "wavy"
     | `solid => "solid"
     | `double => "double"
     | `dotted => "dotted"
     | `dashed => "dashed"
-  });
+    },
+  );
 
 let textIndent = x => d("textIndent", string_of_length(x));
 
 let textOverflow = x =>
-  d( "textOverflow", switch x {
+  d(
+    "textOverflow",
+    switch (x) {
     | `clip => "clip"
     | `ellipsis => "ellipsis"
     | `string(s) => s
-  });
+    },
+  );
 
 let textShadow = (~x=zero, ~y=zero, ~blur=zero, color) =>
-  d( "textShadow", join( " ", [
-    string_of_length(x),
-    string_of_length(y),
-    string_of_length(blur),
-    string_of_color(color)
-  ]));
+  d(
+    "textShadow",
+    join(
+      " ",
+      [
+        string_of_length(x),
+        string_of_length(y),
+        string_of_length(blur),
+        string_of_color(color),
+      ],
+    ),
+  );
 
 let textTransform = x =>
-  d( "textTransform", switch x {
+  d(
+    "textTransform",
+    switch (x) {
     | `uppercase => "uppercase"
     | `lowercase => "lowercase"
     | `capitalize => "capitalize"
     | `none => "none"
-  });
+    },
+  );
 
 let userSelect = x =>
-  d("userSelect", switch x {
+  d(
+    "userSelect",
+    switch (x) {
     | `auto => "auto"
     | `all => "all"
     | `text => "text"
     | `none => "none"
-  });
+    },
+  );
 
 let verticalAlign = x =>
-  d( "verticalAlign", switch x {
+  d(
+    "verticalAlign",
+    switch (x) {
     | `baseline => "baseline"
     | `sub => "sub"
     | `super => "super"
@@ -1197,8 +1463,10 @@ let verticalAlign = x =>
     | `middle => "middle"
     | `bottom => "bottom"
     | `textBottom => "text-bottom"
-    | `calc(`add, a, b) => "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
-    | `calc(`sub, a, b) => "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
+    | `calc(`add, a, b) =>
+      "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
+    | `calc(`sub, a, b) =>
+      "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
     | `ch(x) => string_of_float(x) ++ "ch"
     | `cm(x) => string_of_float(x) ++ "cm"
     | `em(x) => string_of_float(x) ++ "em"
@@ -1214,29 +1482,40 @@ let verticalAlign = x =>
     | `vw(x) => string_of_float(x) ++ "vw"
     | `auto => "auto"
     | `zero => "0"
-    });
+    },
+  );
 
 let whiteSpace = x =>
-  d( "whiteSpace", switch x {
+  d(
+    "whiteSpace",
+    switch (x) {
     | `normal => "normal"
     | `nowrap => "nowrap"
     | `pre => "pre"
     | `preLine => "pre-line"
     | `preWrap => "pre-wrap"
-  });
+    },
+  );
 
 let wordBreak = x =>
-  d( "wordBreak", switch x {
+  d(
+    "wordBreak",
+    switch (x) {
     | `breakAll => "break-all"
     | `keepAll => "keep-all"
     | `normal => "normal"
-  });
+    },
+  );
 
 let wordSpacing = x =>
-  d( "wordSpacing", switch x {
+  d(
+    "wordSpacing",
+    switch (x) {
     | `normal => "normal"
-    | `calc(`add, a, b) => "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
-    | `calc(`sub, a, b) => "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
+    | `calc(`add, a, b) =>
+      "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
+    | `calc(`sub, a, b) =>
+      "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
     | `ch(x) => string_of_float(x) ++ "ch"
     | `cm(x) => string_of_float(x) ++ "cm"
     | `em(x) => string_of_float(x) ++ "em"
@@ -1252,13 +1531,17 @@ let wordSpacing = x =>
     | `vw(x) => string_of_float(x) ++ "vw"
     | `auto => "auto"
     | `zero => "0"
-  });
+    },
+  );
 
 let wordWrap = x =>
-  d( "wordWrap", switch x {
+  d(
+    "wordWrap",
+    switch (x) {
     | `normal => "normal"
     | `breakWord => "break-word"
-  });
+    },
+  );
 
 let string_of_pointerEvents =
   fun
@@ -1266,7 +1549,6 @@ let string_of_pointerEvents =
   | `none => "none";
 
 let pointerEvents = x => d("pointerEvents", string_of_pointerEvents(x));
-
 
 /**
  * Transform
@@ -1295,18 +1577,30 @@ type transform = [
 
 let string_of_transform =
   fun
-  | `translate(x, y) => func("translate", [string_of_length(x), string_of_length(y)])
-  | `translate3d(x, y, z) => func("translate3d", List.map(string_of_length, [x, y, z]))
+  | `translate(x, y) =>
+    func("translate", [string_of_length(x), string_of_length(y)])
+  | `translate3d(x, y, z) =>
+    func("translate3d", List.map(string_of_length, [x, y, z]))
   | `translateX(x) => func("translateX", [string_of_length(x)])
   | `translateY(y) => func("translateY", [string_of_length(y)])
   | `translateZ(z) => func("translateZ", [string_of_length(z)])
   | `scale(x, y) => func("scale", List.map(string_of_float, [x, y]))
-  | `scale3d(x, y, z) => func("scale3d", List.map(string_of_float, [x, y, z]))
+  | `scale3d(x, y, z) =>
+    func("scale3d", List.map(string_of_float, [x, y, z]))
   | `scaleX(x) => func("scaleX", [string_of_float(x)])
   | `scaleY(y) => func("scaleY", [string_of_float(y)])
   | `scaleZ(z) => func("scaleZ", [string_of_float(z)])
   | `rotate(a) => func("rotate", [string_of_angle(a)])
-  | `rotate3d(x, y, z, a) => func( "rotate3d", [ string_of_float(x), string_of_float(y), string_of_float(z), string_of_angle(a) ])
+  | `rotate3d(x, y, z, a) =>
+    func(
+      "rotate3d",
+      [
+        string_of_float(x),
+        string_of_float(y),
+        string_of_float(z),
+        string_of_angle(a),
+      ],
+    )
   | `rotateX(a) => func("rotateX", [string_of_angle(a)])
   | `rotateY(a) => func("rotateY", [string_of_angle(a)])
   | `rotateZ(a) => func("rotateZ", [string_of_angle(a)])
@@ -1324,33 +1618,45 @@ let transformOrigin = (x, y) =>
   d("transformOrigin", [x, y] |> List.map(string_of_length) |> join(" "));
 
 let transformOrigin3d = (x, y, z) =>
-  d("transformOrigin", [x, y, z] |> List.map(string_of_length) |> join(" "));
+  d(
+    "transformOrigin",
+    [x, y, z] |> List.map(string_of_length) |> join(" "),
+  );
 
 let transformStyle = x =>
-  d( "transformStyle", switch x {
+  d(
+    "transformStyle",
+    switch (x) {
     | `preserve3d => "preserve-3d"
     | `flat => "flat"
-  });
+    },
+  );
 
-let perspective = x => d("parspective", switch x {
-| `none => "none"
-| `calc(`add, a, b) => "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
-| `calc(`sub, a, b) => "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
-| `ch(x) => string_of_float(x) ++ "ch"
-| `cm(x) => string_of_float(x) ++ "cm"
-| `em(x) => string_of_float(x) ++ "em"
-| `ex(x) => string_of_float(x) ++ "ex"
-| `mm(x) => string_of_float(x) ++ "mm"
-| `percent(x) => string_of_float(x) ++ "%"
-| `pt(x) => string_of_int(x) ++ "pt"
-| `px(x) => string_of_int(x) ++ "px"
-| `rem(x) => string_of_float(x) ++ "rem"
-| `vh(x) => string_of_float(x) ++ "vh"
-| `vmax(x) => string_of_float(x) ++ "vmax"
-| `vmin(x) => string_of_float(x) ++ "vmin"
-| `vw(x) => string_of_float(x) ++ "vw"
-| `zero => "0";
-});
+let perspective = x =>
+  d(
+    "parspective",
+    switch (x) {
+    | `none => "none"
+    | `calc(`add, a, b) =>
+      "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
+    | `calc(`sub, a, b) =>
+      "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
+    | `ch(x) => string_of_float(x) ++ "ch"
+    | `cm(x) => string_of_float(x) ++ "cm"
+    | `em(x) => string_of_float(x) ++ "em"
+    | `ex(x) => string_of_float(x) ++ "ex"
+    | `mm(x) => string_of_float(x) ++ "mm"
+    | `percent(x) => string_of_float(x) ++ "%"
+    | `pt(x) => string_of_int(x) ++ "pt"
+    | `px(x) => string_of_int(x) ++ "px"
+    | `rem(x) => string_of_float(x) ++ "rem"
+    | `vh(x) => string_of_float(x) ++ "vh"
+    | `vmax(x) => string_of_float(x) ++ "vmax"
+    | `vmin(x) => string_of_float(x) ++ "vmin"
+    | `vw(x) => string_of_float(x) ++ "vw"
+    | `zero => "0"
+    },
+  );
 
 /**
 * Transition
@@ -1378,18 +1684,32 @@ let string_of_timingFunction =
   | `stepEnd => "step-end"
   | `steps(i, `start) => func("steps", [string_of_int(i), "start"])
   | `steps(i, `end_) => func("steps", [string_of_int(i), "end"])
-  | `cubicBezier(a, b, c, d) => func("cubic-bezier", [a, b, c, d] |> List.map(string_of_float));
+  | `cubicBezier(a, b, c, d) =>
+    func("cubic-bezier", [a, b, c, d] |> List.map(string_of_float));
 
 let transition = (~duration=0, ~delay=0, ~timingFunction=`ease, property) =>
-  `transition(join( " ", [
-    string_of_int(duration) ++ "ms",
-    string_of_timingFunction(timingFunction),
-    string_of_int(delay) ++ "ms",
-    property
-  ]));
+  `transition(
+    join(
+      " ",
+      [
+        string_of_int(duration) ++ "ms",
+        string_of_timingFunction(timingFunction),
+        string_of_int(delay) ++ "ms",
+        property,
+      ],
+    ),
+  );
 
 let transitions = xs =>
-  d("transition", xs |> List.map(fun | `transition(s) => s) |> join(", "));
+  d(
+    "transition",
+    xs
+    |> List.map(
+         fun
+         | `transition(s) => s,
+       )
+    |> join(", "),
+  );
 
 let transitionDelay = i => d("transitionDelay", string_of_int(i) ++ "ms");
 
@@ -1402,7 +1722,10 @@ let transitionTimingFunction = x =>
 let transitionProperty = x => d("transitionProperty", x);
 
 let perspectiveOrigin = (x, y) =>
-  d("perspectiveOrigin", [x, y] |> List.map(string_of_length) |> join(" "));
+  d(
+    "perspectiveOrigin",
+    [x, y] |> List.map(string_of_length) |> join(" "),
+  );
 
 /**
  * Animation
@@ -1445,7 +1768,8 @@ let string_of_animationPlayState =
   | `paused => "paused"
   | `running => "running";
 
-let animation = (
+let animation =
+    (
       ~duration=0,
       ~delay=0,
       ~direction=`normal,
@@ -1453,37 +1777,50 @@ let animation = (
       ~fillMode=`none,
       ~playState=`running,
       ~iterationCount=`count(1),
-      name
+      name,
     ) =>
-  `animation(join( " ", [
-    name,
-    string_of_int(duration) ++ "ms",
-    string_of_timingFunction(timingFunction),
-    string_of_int(delay) ++ "ms",
-    string_of_animationIterationCount(iterationCount),
-    string_of_animationDirection(direction),
-    string_of_animationFillMode(fillMode),
-    string_of_animationPlayState(playState)
-  ]));
+  `animation(
+    join(
+      " ",
+      [
+        name,
+        string_of_int(duration) ++ "ms",
+        string_of_timingFunction(timingFunction),
+        string_of_int(delay) ++ "ms",
+        string_of_animationIterationCount(iterationCount),
+        string_of_animationDirection(direction),
+        string_of_animationFillMode(fillMode),
+        string_of_animationPlayState(playState),
+      ],
+    ),
+  );
 
-let string_of_animation = fun
-| `animation(s) => s;
-let animations = xs => d("animation", xs |> List.map(string_of_animation) |> join(", "));
+let string_of_animation =
+  fun
+  | `animation(s) => s;
+let animations = xs =>
+  d("animation", xs |> List.map(string_of_animation) |> join(", "));
 
 let animationDelay = x => d("animationDelay", string_of_int(x) ++ "ms");
-let animationDirection = x => d("animationDirection", string_of_animationDirection(x));
-let animationDuration = x => d("animationDuration", string_of_int(x) ++ "ms");
-let animationFillMode = x => d("animationFillMode", string_of_animationFillMode(x));
-let animationIterationCount = x => d("animationIterationCount", string_of_animationIterationCount(x));
+let animationDirection = x =>
+  d("animationDirection", string_of_animationDirection(x));
+let animationDuration = x =>
+  d("animationDuration", string_of_int(x) ++ "ms");
+let animationFillMode = x =>
+  d("animationFillMode", string_of_animationFillMode(x));
+let animationIterationCount = x =>
+  d("animationIterationCount", string_of_animationIterationCount(x));
 let animationName = x => d("animationName", x);
-let animationPlayState = x => d("animationPlayState", string_of_animationPlayState(x));
-let animationTimingFunction = x => d("animationTimingFunction", string_of_timingFunction(x));
+let animationPlayState = x =>
+  d("animationPlayState", string_of_animationPlayState(x));
+let animationTimingFunction = x =>
+  d("animationTimingFunction", string_of_timingFunction(x));
 
 /**
  * Selectors
  */
 
-let selector = (selector, rules) => `selector(selector, rules);
+let selector = (selector, rules) => `selector((selector, rules));
 /* MEDIA */
 let active = selector(":active");
 let after = selector("::after");
@@ -1515,35 +1852,46 @@ let firstLetter = selector("::first-letter");
 let selection = selector("::selection");
 let placeholder = selector("::placeholder");
 
-let media = (query, rules) => `selector("@media " ++ query, rules);
-
+let media = (query, rules) => `selector(("@media " ++ query, rules));
 
 /**
  * SVG
  */
-
 module SVG = {
   let fill = color => d("fill", string_of_color(color));
   let fillOpacity = opacity => d("fillOpacity", string_of_float(opacity));
-  let fillRule = x => d("fillRule", switch x {
-    | `evenodd => "evenodd"
-    | `nonzero => "nonzero"
-  });
+  let fillRule = x =>
+    d(
+      "fillRule",
+      switch (x) {
+      | `evenodd => "evenodd"
+      | `nonzero => "nonzero"
+      },
+    );
   let stroke = color => d("stroke", string_of_color(color));
   let strokeWidth = length => d("strokeWidth", string_of_length(length));
-  let strokeOpacity = opacity => d("strokeOpacity", string_of_float(opacity));
+  let strokeOpacity = opacity =>
+    d("strokeOpacity", string_of_float(opacity));
   let strokeMiterlimit = x => d("strokeMiterlimit", string_of_float(x));
-  let strokeLinecap = x => d("strokeLinecap", switch x {
-  | `butt => "butt"
-  | `round => "round"
-  | `square => "square"
-  });
+  let strokeLinecap = x =>
+    d(
+      "strokeLinecap",
+      switch (x) {
+      | `butt => "butt"
+      | `round => "round"
+      | `square => "square"
+      },
+    );
 
-  let strokeLinejoin = x => d("strokeLinejoin", switch x {
-    | `miter => "miter"
-    | `round => "round"
-    | `bevel => "bevel"
-  });
+  let strokeLinejoin = x =>
+    d(
+      "strokeLinejoin",
+      switch (x) {
+      | `miter => "miter"
+      | `round => "round"
+      | `bevel => "bevel"
+      },
+    );
   let stopColor = c => d("stopColor", string_of_color(c));
   let stopOpacity = o => d("stopOpacity", string_of_float(o));
 };

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -4,30 +4,25 @@ type rule = [
   | `animation(string)
   | `transition(string)
   | `shadow(string)
-  ];
+];
 
-let empty : list(rule);
-let merge : list(list(rule)) => list(rule);
-let style : list(rule) => string;
+let empty: list(rule);
+let merge: list(list(rule)) => list(rule);
+let style: list(rule) => string;
 
-let global : (string, list(rule)) => unit;
-let important : rule => rule;
-let label : string => rule;
+let global: (string, list(rule)) => unit;
+let important: rule => rule;
+let label: string => rule;
 
 /********************************************************
  ************************ VALUES ************************
  ********************************************************/
-type angle = [
-  | `deg(int)
-  | `rad(float)
-  | `grad(float)
-  | `turn(float)
-];
+type angle = [ | `deg(int) | `rad(float) | `grad(float) | `turn(float)];
 
-let deg : int => [> | `deg(int)];
-let rad : float => [> | `rad(float)];
-let grad : float => [> | `grad(float)];
-let turn : float => [> | `turn(float)];
+let deg: int => [> | `deg(int)];
+let rad: float => [> | `rad(float)];
+let grad: float => [> | `grad(float)];
+let turn: float => [> | `turn(float)];
 
 type color = [
   | `rgb(int, int, int)
@@ -39,13 +34,13 @@ type color = [
   | `currentColor
 ];
 
-let rgb : (int, int, int) => [> | `rgb(int, int, int)];
-let rgba : (int, int, int, float) => [> | `rgba(int, int, int, float)];
-let hsl : (int, int, int) => [> | `hsl(int, int, int)];
-let hsla : (int, int, int, float) => [> | `hsla(int, int, int, float)];
-let hex : string => [> | `hex(string)];
-let transparent : [> | `transparent];
-let currentColor : [> | `currentColor];
+let rgb: (int, int, int) => [> | `rgb(int, int, int)];
+let rgba: (int, int, int, float) => [> | `rgba(int, int, int, float)];
+let hsl: (int, int, int) => [> | `hsl(int, int, int)];
+let hsla: (int, int, int, float) => [> | `hsla(int, int, int, float)];
+let hex: string => [> | `hex(string)];
+let transparent: [> | `transparent];
+let currentColor: [> | `currentColor];
 
 type gradient = [
   | `linearGradient(angle, list((int, color)))
@@ -54,162 +49,168 @@ type gradient = [
   | `repeatingRadialGradient(list((int, color)))
 ];
 
-let linearGradient: (angle, list((int, color))) => [> | `linearGradient(angle, list((int, color)))];
-let repeatingLinearGradient: (angle, list((int, color))) => [> | `repeatingLinearGradient(angle, list((int, color)))];
-let radialGradient: (list((int, color))) => [> | `radialGradient(list((int, color)))];
-let repeatingRadialGradient: (list((int, color))) => [> | `repeatingRadialGradient(list((int, color)))];
+let linearGradient:
+  (angle, list((int, color))) =>
+  [> | `linearGradient(angle, list((int, color)))];
+let repeatingLinearGradient:
+  (angle, list((int, color))) =>
+  [> | `repeatingLinearGradient(angle, list((int, color)))];
+let radialGradient:
+  list((int, color)) => [> | `radialGradient(list((int, color)))];
+let repeatingRadialGradient:
+  list((int, color)) => [> | `repeatingRadialGradient(list((int, color)))];
 
-let aliceblue : [> | `hex(string)];
-let antiquewhite : [> | `hex(string)];
-let aqua : [> | `hex(string)];
-let aquamarine : [> | `hex(string)];
-let azure : [> | `hex(string)];
-let beige : [> | `hex(string)];
-let bisque : [> | `hex(string)];
-let black : [> | `hex(string)];
-let blanchedalmond : [> | `hex(string)];
-let blue : [> | `hex(string)];
-let blueviolet : [> | `hex(string)];
-let brown : [> | `hex(string)];
-let burlywood : [> | `hex(string)];
-let cadetblue : [> | `hex(string)];
-let chartreuse : [> | `hex(string)];
-let chocolate : [> | `hex(string)];
-let coral : [> | `hex(string)];
-let cornflowerblue : [> | `hex(string)];
-let cornsilk : [> | `hex(string)];
-let crimson : [> | `hex(string)];
-let cyan : [> | `hex(string)];
-let darkblue : [> | `hex(string)];
-let darkcyan : [> | `hex(string)];
-let darkgoldenrod : [> | `hex(string)];
-let darkgray : [> | `hex(string)];
-let darkgrey : [> | `hex(string)];
-let darkgreen : [> | `hex(string)];
-let darkkhaki : [> | `hex(string)];
-let darkmagenta : [> | `hex(string)];
-let darkolivegreen : [> | `hex(string)];
-let darkorange : [> | `hex(string)];
-let darkorchid : [> | `hex(string)];
-let darkred : [> | `hex(string)];
-let darksalmon : [> | `hex(string)];
-let darkseagreen : [> | `hex(string)];
-let darkslateblue : [> | `hex(string)];
-let darkslategray : [> | `hex(string)];
-let darkslategrey : [> | `hex(string)];
-let darkturquoise : [> | `hex(string)];
-let darkviolet : [> | `hex(string)];
-let deeppink : [> | `hex(string)];
-let deepskyblue : [> | `hex(string)];
-let dimgray : [> | `hex(string)];
-let dimgrey : [> | `hex(string)];
-let dodgerblue : [> | `hex(string)];
-let firebrick : [> | `hex(string)];
-let floralwhite : [> | `hex(string)];
-let forestgreen : [> | `hex(string)];
-let fuchsia : [> | `hex(string)];
-let gainsboro : [> | `hex(string)];
-let ghostwhite : [> | `hex(string)];
-let gold : [> | `hex(string)];
-let goldenrod : [> | `hex(string)];
-let gray : [> | `hex(string)];
-let grey : [> | `hex(string)];
-let green : [> | `hex(string)];
-let greenyellow : [> | `hex(string)];
-let honeydew : [> | `hex(string)];
-let hotpink : [> | `hex(string)];
-let indianred : [> | `hex(string)];
-let indigo : [> | `hex(string)];
-let ivory : [> | `hex(string)];
-let khaki : [> | `hex(string)];
-let lavender : [> | `hex(string)];
-let lavenderblush : [> | `hex(string)];
-let lawngreen : [> | `hex(string)];
-let lemonchiffon : [> | `hex(string)];
-let lightblue : [> | `hex(string)];
-let lightcoral : [> | `hex(string)];
-let lightcyan : [> | `hex(string)];
-let lightgoldenrodyellow : [> | `hex(string)];
-let lightgray : [> | `hex(string)];
-let lightgrey : [> | `hex(string)];
-let lightgreen : [> | `hex(string)];
-let lightpink : [> | `hex(string)];
-let lightsalmon : [> | `hex(string)];
-let lightseagreen : [> | `hex(string)];
-let lightskyblue : [> | `hex(string)];
-let lightslategray : [> | `hex(string)];
-let lightslategrey : [> | `hex(string)];
-let lightsteelblue : [> | `hex(string)];
-let lightyellow : [> | `hex(string)];
-let lime : [> | `hex(string)];
-let limegreen : [> | `hex(string)];
-let linen : [> | `hex(string)];
-let magenta : [> | `hex(string)];
-let maroon : [> | `hex(string)];
-let mediumaquamarine : [> | `hex(string)];
-let mediumblue : [> | `hex(string)];
-let mediumorchid : [> | `hex(string)];
-let mediumpurple : [> | `hex(string)];
-let mediumseagreen : [> | `hex(string)];
-let mediumslateblue : [> | `hex(string)];
-let mediumspringgreen : [> | `hex(string)];
-let mediumturquoise : [> | `hex(string)];
-let mediumvioletred : [> | `hex(string)];
-let midnightblue : [> | `hex(string)];
-let mintcream : [> | `hex(string)];
-let mistyrose : [> | `hex(string)];
-let moccasin : [> | `hex(string)];
-let navajowhite : [> | `hex(string)];
-let navy : [> | `hex(string)];
-let oldlace : [> | `hex(string)];
-let olive : [> | `hex(string)];
-let olivedrab : [> | `hex(string)];
-let orange : [> | `hex(string)];
-let orangered : [> | `hex(string)];
-let orchid : [> | `hex(string)];
-let palegoldenrod : [> | `hex(string)];
-let palegreen : [> | `hex(string)];
-let paleturquoise : [> | `hex(string)];
-let palevioletred : [> | `hex(string)];
-let papayawhip : [> | `hex(string)];
-let peachpuff : [> | `hex(string)];
-let peru : [> | `hex(string)];
-let pink : [> | `hex(string)];
-let plum : [> | `hex(string)];
-let powderblue : [> | `hex(string)];
-let purple : [> | `hex(string)];
-let rebeccapurple : [> | `hex(string)];
-let red : [> | `hex(string)];
-let rosybrown : [> | `hex(string)];
-let royalblue : [> | `hex(string)];
-let saddlebrown : [> | `hex(string)];
-let salmon : [> | `hex(string)];
-let sandybrown : [> | `hex(string)];
-let seagreen : [> | `hex(string)];
-let seashell : [> | `hex(string)];
-let sienna : [> | `hex(string)];
-let silver : [> | `hex(string)];
-let skyblue : [> | `hex(string)];
-let slateblue : [> | `hex(string)];
-let slategray : [> | `hex(string)];
-let slategrey : [> | `hex(string)];
-let snow : [> | `hex(string)];
-let springgreen : [> | `hex(string)];
-let steelblue : [> | `hex(string)];
-let tan : [> | `hex(string)];
-let teal : [> | `hex(string)];
-let thistle : [> | `hex(string)];
-let tomato : [> | `hex(string)];
-let turquoise : [> | `hex(string)];
-let violet : [> | `hex(string)];
-let wheat : [> | `hex(string)];
-let white : [> | `hex(string)];
-let whitesmoke : [> | `hex(string)];
-let yellow : [> | `hex(string)];
-let yellowgreen : [> | `hex(string)];
+let aliceblue: [> | `hex(string)];
+let antiquewhite: [> | `hex(string)];
+let aqua: [> | `hex(string)];
+let aquamarine: [> | `hex(string)];
+let azure: [> | `hex(string)];
+let beige: [> | `hex(string)];
+let bisque: [> | `hex(string)];
+let black: [> | `hex(string)];
+let blanchedalmond: [> | `hex(string)];
+let blue: [> | `hex(string)];
+let blueviolet: [> | `hex(string)];
+let brown: [> | `hex(string)];
+let burlywood: [> | `hex(string)];
+let cadetblue: [> | `hex(string)];
+let chartreuse: [> | `hex(string)];
+let chocolate: [> | `hex(string)];
+let coral: [> | `hex(string)];
+let cornflowerblue: [> | `hex(string)];
+let cornsilk: [> | `hex(string)];
+let crimson: [> | `hex(string)];
+let cyan: [> | `hex(string)];
+let darkblue: [> | `hex(string)];
+let darkcyan: [> | `hex(string)];
+let darkgoldenrod: [> | `hex(string)];
+let darkgray: [> | `hex(string)];
+let darkgrey: [> | `hex(string)];
+let darkgreen: [> | `hex(string)];
+let darkkhaki: [> | `hex(string)];
+let darkmagenta: [> | `hex(string)];
+let darkolivegreen: [> | `hex(string)];
+let darkorange: [> | `hex(string)];
+let darkorchid: [> | `hex(string)];
+let darkred: [> | `hex(string)];
+let darksalmon: [> | `hex(string)];
+let darkseagreen: [> | `hex(string)];
+let darkslateblue: [> | `hex(string)];
+let darkslategray: [> | `hex(string)];
+let darkslategrey: [> | `hex(string)];
+let darkturquoise: [> | `hex(string)];
+let darkviolet: [> | `hex(string)];
+let deeppink: [> | `hex(string)];
+let deepskyblue: [> | `hex(string)];
+let dimgray: [> | `hex(string)];
+let dimgrey: [> | `hex(string)];
+let dodgerblue: [> | `hex(string)];
+let firebrick: [> | `hex(string)];
+let floralwhite: [> | `hex(string)];
+let forestgreen: [> | `hex(string)];
+let fuchsia: [> | `hex(string)];
+let gainsboro: [> | `hex(string)];
+let ghostwhite: [> | `hex(string)];
+let gold: [> | `hex(string)];
+let goldenrod: [> | `hex(string)];
+let gray: [> | `hex(string)];
+let grey: [> | `hex(string)];
+let green: [> | `hex(string)];
+let greenyellow: [> | `hex(string)];
+let honeydew: [> | `hex(string)];
+let hotpink: [> | `hex(string)];
+let indianred: [> | `hex(string)];
+let indigo: [> | `hex(string)];
+let ivory: [> | `hex(string)];
+let khaki: [> | `hex(string)];
+let lavender: [> | `hex(string)];
+let lavenderblush: [> | `hex(string)];
+let lawngreen: [> | `hex(string)];
+let lemonchiffon: [> | `hex(string)];
+let lightblue: [> | `hex(string)];
+let lightcoral: [> | `hex(string)];
+let lightcyan: [> | `hex(string)];
+let lightgoldenrodyellow: [> | `hex(string)];
+let lightgray: [> | `hex(string)];
+let lightgrey: [> | `hex(string)];
+let lightgreen: [> | `hex(string)];
+let lightpink: [> | `hex(string)];
+let lightsalmon: [> | `hex(string)];
+let lightseagreen: [> | `hex(string)];
+let lightskyblue: [> | `hex(string)];
+let lightslategray: [> | `hex(string)];
+let lightslategrey: [> | `hex(string)];
+let lightsteelblue: [> | `hex(string)];
+let lightyellow: [> | `hex(string)];
+let lime: [> | `hex(string)];
+let limegreen: [> | `hex(string)];
+let linen: [> | `hex(string)];
+let magenta: [> | `hex(string)];
+let maroon: [> | `hex(string)];
+let mediumaquamarine: [> | `hex(string)];
+let mediumblue: [> | `hex(string)];
+let mediumorchid: [> | `hex(string)];
+let mediumpurple: [> | `hex(string)];
+let mediumseagreen: [> | `hex(string)];
+let mediumslateblue: [> | `hex(string)];
+let mediumspringgreen: [> | `hex(string)];
+let mediumturquoise: [> | `hex(string)];
+let mediumvioletred: [> | `hex(string)];
+let midnightblue: [> | `hex(string)];
+let mintcream: [> | `hex(string)];
+let mistyrose: [> | `hex(string)];
+let moccasin: [> | `hex(string)];
+let navajowhite: [> | `hex(string)];
+let navy: [> | `hex(string)];
+let oldlace: [> | `hex(string)];
+let olive: [> | `hex(string)];
+let olivedrab: [> | `hex(string)];
+let orange: [> | `hex(string)];
+let orangered: [> | `hex(string)];
+let orchid: [> | `hex(string)];
+let palegoldenrod: [> | `hex(string)];
+let palegreen: [> | `hex(string)];
+let paleturquoise: [> | `hex(string)];
+let palevioletred: [> | `hex(string)];
+let papayawhip: [> | `hex(string)];
+let peachpuff: [> | `hex(string)];
+let peru: [> | `hex(string)];
+let pink: [> | `hex(string)];
+let plum: [> | `hex(string)];
+let powderblue: [> | `hex(string)];
+let purple: [> | `hex(string)];
+let rebeccapurple: [> | `hex(string)];
+let red: [> | `hex(string)];
+let rosybrown: [> | `hex(string)];
+let royalblue: [> | `hex(string)];
+let saddlebrown: [> | `hex(string)];
+let salmon: [> | `hex(string)];
+let sandybrown: [> | `hex(string)];
+let seagreen: [> | `hex(string)];
+let seashell: [> | `hex(string)];
+let sienna: [> | `hex(string)];
+let silver: [> | `hex(string)];
+let skyblue: [> | `hex(string)];
+let slateblue: [> | `hex(string)];
+let slategray: [> | `hex(string)];
+let slategrey: [> | `hex(string)];
+let snow: [> | `hex(string)];
+let springgreen: [> | `hex(string)];
+let steelblue: [> | `hex(string)];
+let tan: [> | `hex(string)];
+let teal: [> | `hex(string)];
+let thistle: [> | `hex(string)];
+let tomato: [> | `hex(string)];
+let turquoise: [> | `hex(string)];
+let violet: [> | `hex(string)];
+let wheat: [> | `hex(string)];
+let white: [> | `hex(string)];
+let whitesmoke: [> | `hex(string)];
+let yellow: [> | `hex(string)];
+let yellowgreen: [> | `hex(string)];
 
 type length = [
-  | `calc( [ | `add | `sub], length, length)
+  | `calc([ | `add | `sub], length, length)
   | `ch(float)
   | `cm(float)
   | `em(float)
@@ -226,358 +227,419 @@ type length = [
   | `zero
 ];
 
-type gridLength = [ length | `fr(float) ];
+type gridLength = [ length | `fr(float)];
 
-let ch : float => [> | `ch(float)];
-let cm : float => [> | `cm(float)];
-let em : float => [> | `em(float)];
-let ex : float => [> | `ex(float)];
-let fr : float => [> | `fr(float)];
-let mm : float => [> | `mm(float)];
-let pct : float => [> | `percent(float)];
-let pt : int => [> | `pt(int)];
-let px : int => [> | `px(int)];
-let rem : float => [> | `rem(float)];
-let vh : float => [> | `vh(float)];
-let vmax : float => [> | `vmax(float)];
-let vmin : float => [> | `vmin(float)];
-let vw : float => [> | `vw(float)];
-let zero : [> | `zero];
-
+let ch: float => [> | `ch(float)];
+let cm: float => [> | `cm(float)];
+let em: float => [> | `em(float)];
+let ex: float => [> | `ex(float)];
+let fr: float => [> | `fr(float)];
+let mm: float => [> | `mm(float)];
+let pct: float => [> | `percent(float)];
+let pt: int => [> | `pt(int)];
+let px: int => [> | `px(int)];
+let rem: float => [> | `rem(float)];
+let vh: float => [> | `vh(float)];
+let vmax: float => [> | `vmax(float)];
+let vmin: float => [> | `vmin(float)];
+let vw: float => [> | `vw(float)];
+let zero: [> | `zero];
 
 module Calc: {
-  let (-): (length, length) => [> | length];
-  let (+): (length, length) => [> | length];
+  let (-): (length, length) => [> length];
+  let (+): (length, length) => [> length];
 };
 
-let size : (length, length) => [> |`size(length, length)];
+let size: (length, length) => [> | `size(length, length)];
 
-let solid : [> | `solid];
-let dotted : [> | `dotted];
-let dashed : [> | `dashed];
+let solid: [> | `solid];
+let dotted: [> | `dotted];
+let dashed: [> | `dashed];
 
-let localUrl : string => [> `localUrl(string)];
-let url : string => [> `url(string)];
+let localUrl: string => [> | `localUrl(string)];
+let url: string => [> | `url(string)];
 
-let none : [> | `none];
-let auto : [> | `auto];
-let hidden : [> | `hidden];
-let visible : [> | `visible];
-let local : [> | `local];
-let scroll : [> | `scroll];
+let none: [> | `none];
+let auto: [> | `auto];
+let hidden: [> | `hidden];
+let visible: [> | `visible];
+let local: [> | `local];
+let scroll: [> | `scroll];
 
-let paddingBox : [> | `paddingBox];
-let borderBox : [> | `borderBox];
-let contentBox : [> | `contentBox];
+let paddingBox: [> | `paddingBox];
+let borderBox: [> | `borderBox];
+let contentBox: [> | `contentBox];
 
-let noRepeat : [> | `noRepeat];
-let repeat : [> | `repeat];
-let repeatX : [> | `repeatX];
-let repeatY : [> | `repeatY];
-let contain : [> | `contain];
-let cover : [> | `cover];
+let noRepeat: [> | `noRepeat];
+let repeat: [> | `repeat];
+let repeatX: [> | `repeatX];
+let repeatY: [> | `repeatY];
+let contain: [> | `contain];
+let cover: [> | `cover];
 
-let row : [> | `row];
-let rowReverse : [> | `rowReverse];
-let column : [> | `column];
-let columnReverse : [> | `columnReverse];
-let wrap : [> | `wrap];
-let nowrap : [> | `nowrap];
-let wrapReverse : [> | `wrapReverse];
+let row: [> | `row];
+let rowReverse: [> | `rowReverse];
+let column: [> | `column];
+let columnReverse: [> | `columnReverse];
+let wrap: [> | `wrap];
+let nowrap: [> | `nowrap];
+let wrapReverse: [> | `wrapReverse];
 
-let flexBox : [> | `flex];
-let grid : [> `grid ];
-let inlineGrid : [> `inlineGrid ];
-let block : [> | `block];
-let inline : [> | `inline];
-let inlineBlock : [> | `inlineBlock];
+let flexBox: [> | `flex];
+let grid: [> | `grid];
+let inlineGrid: [> | `inlineGrid];
+let block: [> | `block];
+let inline: [> | `inline];
+let inlineBlock: [> | `inlineBlock];
 
-let absolute : [> | `absolute];
-let relative : [> | `relative];
-let static : [> | `static];
-let fixed : [> | `fixed];
-let sticky : [> | `sticky];
+let absolute: [> | `absolute];
+let relative: [> | `relative];
+let static: [> | `static];
+let fixed: [> | `fixed];
+let sticky: [> | `sticky];
 
-let flexStart : [> | `flexStart];
-let flexEnd : [> | `flexEnd];
-let center : [> | `center];
-let stretch : [> | `stretch];
-let spaceBetween : [> | `spaceBetween];
-let spaceAround : [> | `spaceAround];
-let baseline : [> | `baseline];
+let flexStart: [> | `flexStart];
+let flexEnd: [> | `flexEnd];
+let center: [> | `center];
+let stretch: [> | `stretch];
+let spaceBetween: [> | `spaceBetween];
+let spaceAround: [> | `spaceAround];
+let baseline: [> | `baseline];
 
-let forwards : [> | `forwards];
-let backwards : [> | `backwards];
-let both : [> | `both];
-let infinite : [> | `infinite];
-let count : int => [> | `count(int)];
-let paused : [> | `paused];
-let running : [> | `running];
+let forwards: [> | `forwards];
+let backwards: [> | `backwards];
+let both: [> | `both];
+let infinite: [> | `infinite];
+let count: int => [> | `count(int)];
+let paused: [> | `paused];
+let running: [> | `running];
 
-let inside : [> | `inside];
-let outside : [> | `outside];
+let inside: [> | `inside];
+let outside: [> | `outside];
 
+let translate: (length, length) => [> | `translate(length, length)];
+let translate3d:
+  (length, length, length) => [> | `translate3d(length, length, length)];
+let translateX: length => [> | `translateX(length)];
+let translateY: length => [> | `translateY(length)];
+let translateZ: length => [> | `translateZ(length)];
+let scale: (float, float) => [> | `scale(float, float)];
+let scale3d: (float, float, float) => [> | `scale3d(float, float, float)];
+let scaleX: float => [> | `scaleX(float)];
+let scaleY: float => [> | `scaleY(float)];
+let scaleZ: float => [> | `scaleZ(float)];
+let rotate: angle => [> | `rotate(angle)];
+let rotate3d:
+  (float, float, float, angle) => [> | `rotate3d(float, float, float, angle)];
+let rotateX: angle => [> | `rotateX(angle)];
+let rotateY: angle => [> | `rotateY(angle)];
+let rotateZ: angle => [> | `rotateZ(angle)];
+let skew: (angle, angle) => [> | `skew(angle, angle)];
+let skewX: angle => [> | `skewX(angle)];
+let skewY: angle => [> | `skewY(angle)];
 
-let translate  : (length, length) => [> | `translate(length, length)];
-let translate3d : (length, length, length) => [> | `translate3d(length, length, length)];
-let translateX : length => [> | `translateX(length)];
-let translateY : length => [> | `translateY(length)];
-let translateZ : length => [> | `translateZ(length)];
-let scale : (float, float) => [> | `scale(float, float)];
-let scale3d : (float, float, float) => [> | `scale3d(float, float, float)];
-let scaleX : float => [> | `scaleX(float)];
-let scaleY : float => [> | `scaleY(float)];
-let scaleZ : float => [> | `scaleZ(float)];
-let rotate : angle => [> | `rotate(angle)];
-let rotate3d : (float, float, float, angle) => [> | `rotate3d(float, float, float, angle)];
-let rotateX : angle => [> | `rotateX(angle)];
-let rotateY : angle => [> | `rotateY(angle)];
-let rotateZ : angle => [> | `rotateZ(angle)];
-let skew : (angle, angle) => [> | `skew(angle, angle)];
-let skewX : (angle) => [> | `skewX(angle)];
-let skewY : (angle) => [> | `skewY(angle)];
+let italic: [> | `italic];
+let oblique: [> | `oblique];
 
-let italic : [> | `italic];
-let oblique : [> | `oblique];
+let underline: [> | `underline];
+let overline: [> | `overline];
+let lineThrough: [> | `lineThough];
 
-let underline : [> | `underline];
-let overline : [> | `overline];
-let lineThrough : [> | `lineThough];
+let clip: [> | `clip];
+let ellipsis: [> | `ellipsis];
 
-let clip : [> | `clip];
-let ellipsis : [> | `ellipsis];
+let wavy: [> | `wavy];
+let double: [> | `double];
 
-let wavy : [> | `wavy];
-let double : [> | `double];
+let uppercase: [> | `uppercase];
+let lowercase: [> | `lowercase];
+let capitalize: [> | `capitalize];
 
-let uppercase : [> | `uppercase];
-let lowercase : [> | `lowercase];
-let capitalize : [> | `capitalize];
-
-let sub : [> | `sub];
-let super : [> | `super];
+let sub: [> | `sub];
+let super: [> | `super];
 let textTop: [> | `textTop];
-let textBottom : [> | `textBottom];
-let middle : [> | `middle];
+let textBottom: [> | `textBottom];
+let middle: [> | `middle];
 
-let normal : [> | `normal];
+let normal: [> | `normal];
 
-let breakAll : [> | `breakAll];
-let keepAll : [> | `keepAll];
-let breakWord : [> | `breakWord];
+let breakAll: [> | `breakAll];
+let keepAll: [> | `keepAll];
+let breakWord: [> | `breakWord];
 
-let reverse : [> | `reverse];
-let alternate : [> | `alternate];
-let alternateReverse : [> | `alternateReverse];
+let reverse: [> | `reverse];
+let alternate: [> | `alternate];
+let alternateReverse: [> | `alternateReverse];
 
-let fill : [> | `fill ];
-let content : [> | `content];
-let maxContent : [> | `maxContent];
-let minContent : [> | `minContent];
-let fitContent : [> | `fitContent];
+let fill: [> | `fill];
+let content: [> | `content];
+let maxContent: [> | `maxContent];
+let minContent: [> | `minContent];
+let fitContent: [> | `fitContent];
 
-let all : [> | `all];
-let text : [> | `text];
+let all: [> | `all];
+let text: [> | `text];
 
-let linear : [> |`linear];
-let ease : [> |`ease];
-let easeIn : [> |`easeIn];
-let easeOut : [> |`easeOut];
-let easeInOut : [> |`easeInOut];
-let stepStart : [> |`stepStart];
-let stepEnd : [> |`stepEnd];
-let steps : (int, [ | `start | `end_]) => [> |`steps(int, [ | `start | `end_])];
-let cubicBesier : (float, float, float, float) =>[> |`cubicBezier(float, float, float, float)];
+let linear: [> | `linear];
+let ease: [> | `ease];
+let easeIn: [> | `easeIn];
+let easeOut: [> | `easeOut];
+let easeInOut: [> | `easeInOut];
+let stepStart: [> | `stepStart];
+let stepEnd: [> | `stepEnd];
+let steps:
+  (int, [ | `start | `end_]) => [> | `steps(int, [ | `start | `end_])];
+let cubicBesier:
+  (float, float, float, float) =>
+  [> | `cubicBezier(float, float, float, float)];
 
-let round : [> | `round];
-let miter : [> | `miter];
-let bevel : [> | `bevel];
-let butt : [> | `butt];
-let square : [> | `square];
+let round: [> | `round];
+let miter: [> | `miter];
+let bevel: [> | `bevel];
+let butt: [> | `butt];
+let square: [> | `square];
 
 /********************************************************
  ******************** PROPERTIES ************************
  ********************************************************/
 
-let unsafe : (string, string) => rule;
+let unsafe: (string, string) => rule;
 
 /**
  * Layout
 */
 
-let display : [ | `flex | `block | `inline | `inlineBlock | `none | `inlineFlex | `grid | `inlineGrid ] => rule;
-let position : [ | `absolute | `relative | `static | `fixed | `sticky ] => rule;
+let display:
+  [
+    | `flex
+    | `block
+    | `inline
+    | `inlineBlock
+    | `none
+    | `inlineFlex
+    | `grid
+    | `inlineGrid
+  ] =>
+  rule;
+let position: [ | `absolute | `relative | `static | `fixed | `sticky] => rule;
 
-let top : [ | length] => rule;
-let bottom : [ | length] => rule;
-let left : [ | length] => rule;
-let right : [ | length] => rule;
+let top: [ length] => rule;
+let bottom: [ length] => rule;
+let left: [ length] => rule;
+let right: [ length] => rule;
 
 let flex: int => rule;
 let flexGrow: int => rule;
 let flexShrink: int => rule;
-let flexBasis: [ | length | `auto | `fill | `content | `maxContent | `minContent | `fitContent ] => rule;
+let flexBasis:
+  [
+    length
+    | `auto
+    | `fill
+    | `content
+    | `maxContent
+    | `minContent
+    | `fitContent
+  ] =>
+  rule;
 
 let flexDirection: [ | `row | `column | `rowReverse | `columnReverse] => rule;
 let flexWrap: [ | `wrap | `nowrap | `wrapReverse] => rule;
 let order: int => rule;
 
-let gridTemplateColumns : list([ | gridLength | `auto]) => rule;
-let gridTemplateRows : list([ | gridLength | `auto]) => rule;
-let gridAutoRows : [ | length | `auto] => rule;
-let gridColumn : (int, int) => rule;
-let gridRow : (int, int) => rule;
-let gridColumnStart : int => rule;
-let gridColumnEnd : int => rule;
-let gridRowStart : int => rule;
-let gridRowEnd : int => rule;
-let gridColumnGap : length => rule;
-let gridRowGap : length => rule;
-let gridGap : length => rule;
+let gridTemplateColumns: list([ gridLength | `auto]) => rule;
+let gridTemplateRows: list([ gridLength | `auto]) => rule;
+let gridAutoRows: [ length | `auto] => rule;
+let gridColumn: (int, int) => rule;
+let gridRow: (int, int) => rule;
+let gridColumnStart: int => rule;
+let gridColumnEnd: int => rule;
+let gridRowStart: int => rule;
+let gridRowEnd: int => rule;
+let gridColumnGap: length => rule;
+let gridRowGap: length => rule;
+let gridGap: length => rule;
 
-let width : [ | length | `auto ] => rule;
-let minWidth : [ | length | `auto ] => rule;
-let maxWidth : [ | length | `auto ] => rule;
-let height : [ | length | `auto ] => rule;
-let minHeight : [ | length | `auto ] => rule;
-let maxHeight : [ | length | `auto ] => rule;
+let width: [ length | `auto] => rule;
+let minWidth: [ length | `auto] => rule;
+let maxWidth: [ length | `auto] => rule;
+let height: [ length | `auto] => rule;
+let minHeight: [ length | `auto] => rule;
+let maxHeight: [ length | `auto] => rule;
 
-let margin : [ | length | `auto] => rule;
-let margin2: (~v: [ | length | `auto ], ~h: [ | length | `auto]) => rule;
-let margin3: (~top: [ | length | `auto], ~h: [ | length | `auto], ~bottom: [ | length | `auto]) => rule;
-let margin4: (~top: [ | length | `auto], ~right: [ | length | `auto], ~bottom: [ | length | `auto], ~left: [ | length | `auto]) => rule;
-let marginLeft : [ | length | `auto] => rule;
-let marginRight : [ | length | `auto] => rule;
-let marginTop : [ | length | `auto] => rule;
-let marginBottom : [ | length | `auto] => rule;
+let margin: [ length | `auto] => rule;
+let margin2: (~v: [ length | `auto], ~h: [ length | `auto]) => rule;
+let margin3:
+  (
+    ~top: [ length | `auto],
+    ~h: [ length | `auto],
+    ~bottom: [ length | `auto]
+  ) =>
+  rule;
+let margin4:
+  (
+    ~top: [ length | `auto],
+    ~right: [ length | `auto],
+    ~bottom: [ length | `auto],
+    ~left: [ length | `auto]
+  ) =>
+  rule;
+let marginLeft: [ length | `auto] => rule;
+let marginRight: [ length | `auto] => rule;
+let marginTop: [ length | `auto] => rule;
+let marginBottom: [ length | `auto] => rule;
 
-let padding : length => rule;
+let padding: length => rule;
 let padding2: (~v: length, ~h: length) => rule;
 let padding3: (~top: length, ~h: length, ~bottom: length) => rule;
-let padding4: (~top: length, ~right: length, ~bottom: length, ~left: length) => rule;
-let paddingLeft : length => rule;
-let paddingRight : length => rule;
-let paddingTop : length => rule;
-let paddingBottom : length => rule;
+let padding4:
+  (~top: length, ~right: length, ~bottom: length, ~left: length) => rule;
+let paddingLeft: length => rule;
+let paddingRight: length => rule;
+let paddingTop: length => rule;
+let paddingBottom: length => rule;
 
-let alignContent : [ | `stretch | `flexStart | `center | `flexEnd | `spaceBetween | `spaceAround] => rule;
-let alignItems : [ | `stretch | `flexStart | `center | `flexEnd | `baseline ] => rule;
-let alignSelf : [ | `stretch | `flexStart | `center | `flexEnd | `baseline | `auto ] => rule;
-let justifyContent : [ | `flexStart | `center | `flexEnd | `spaceBetween | `spaceAround] => rule;
+let alignContent:
+  [
+    | `stretch
+    | `flexStart
+    | `center
+    | `flexEnd
+    | `spaceBetween
+    | `spaceAround
+  ] =>
+  rule;
+let alignItems:
+  [ | `stretch | `flexStart | `center | `flexEnd | `baseline] => rule;
+let alignSelf:
+  [ | `stretch | `flexStart | `center | `flexEnd | `baseline | `auto] => rule;
+let justifyContent:
+  [ | `flexStart | `center | `flexEnd | `spaceBetween | `spaceAround] => rule;
 
-let boxSizing : [ | `borderBox | `contentBox] => rule;
+let boxSizing: [ | `borderBox | `contentBox] => rule;
 
-let float: [ | `left | `right| `none ] => rule;
-let clear: [ | `left | `right | `both ] => rule;
+let float: [ | `left | `right | `none] => rule;
+let clear: [ | `left | `right | `both] => rule;
 
 let overflow: [ | `hidden | `visible | `scroll | `auto] => rule;
 let overflowX: [ | `hidden | `visible | `scroll | `auto] => rule;
 let overflowY: [ | `hidden | `visible | `scroll | `auto] => rule;
 
-let zIndex : int => rule;
-
+let zIndex: int => rule;
 
 /**
  * Style
  */
-let backfaceVisibility : [ | `visible | `hidden] => rule;
-let visibility : [ | `visible | `hidden] => rule;
+let backfaceVisibility: [ | `visible | `hidden] => rule;
+let visibility: [ | `visible | `hidden] => rule;
 
-let border : length => [ | `solid | `dashed | `dotted | `none] => [ | color] => rule;
-let borderWidth : length => rule;
-let borderStyle : [ | `solid | `dashed | `dotted | `none] => rule;
-let borderColor : color => rule;
+let border:
+  (length, [ | `solid | `dashed | `dotted | `none], [ color]) => rule;
+let borderWidth: length => rule;
+let borderStyle: [ | `solid | `dashed | `dotted | `none] => rule;
+let borderColor: color => rule;
 
-let borderTop : (length, [ | `solid | `dashed | `dotted | `none], [ | color]) => rule;
-let borderTopWidth : length => rule;
-let borderTopStyle : [ | `solid | `dashed | `dotted | `none] => rule;
-let borderTopColor : color => rule;
-let borderBottom : (length, [ | `solid | `dashed | `dotted | `none], [ | color]) => rule;
-let borderBottomWidth : length => rule;
-let borderBottomStyle : [ | `solid | `dashed | `dotted | `none] => rule;
-let borderBottomColor : color => rule;
-let borderLeft : (length, [ | `solid | `dashed | `dotted | `none], [ | color]) => rule;
-let borderLeftWidth : length => rule;
-let borderLeftStyle : [ | `solid | `dashed | `dotted | `none] => rule;
-let borderLeftColor : color => rule;
-let borderRight : (length, [ | `solid | `dashed | `dotted], [ | color]) => rule;
-let borderRightWidth : length => rule;
-let borderRightStyle : [ | `solid | `dashed | `dotted | `none] => rule;
-let borderRightColor : color => rule;
+let borderTop:
+  (length, [ | `solid | `dashed | `dotted | `none], [ color]) => rule;
+let borderTopWidth: length => rule;
+let borderTopStyle: [ | `solid | `dashed | `dotted | `none] => rule;
+let borderTopColor: color => rule;
+let borderBottom:
+  (length, [ | `solid | `dashed | `dotted | `none], [ color]) => rule;
+let borderBottomWidth: length => rule;
+let borderBottomStyle: [ | `solid | `dashed | `dotted | `none] => rule;
+let borderBottomColor: color => rule;
+let borderLeft:
+  (length, [ | `solid | `dashed | `dotted | `none], [ color]) => rule;
+let borderLeftWidth: length => rule;
+let borderLeftStyle: [ | `solid | `dashed | `dotted | `none] => rule;
+let borderLeftColor: color => rule;
+let borderRight: (length, [ | `solid | `dashed | `dotted], [ color]) => rule;
+let borderRightWidth: length => rule;
+let borderRightStyle: [ | `solid | `dashed | `dotted | `none] => rule;
+let borderRightColor: color => rule;
 
-
-let borderRadius : length => rule;
-let borderTopLeftRadius : length => rule;
-let borderTopRightRadius : length => rule;
-let borderBottomLeftRadius : length => rule;
-let borderBottomRightRadius : length => rule;
+let borderRadius: length => rule;
+let borderTopLeftRadius: length => rule;
+let borderTopRightRadius: length => rule;
+let borderBottomLeftRadius: length => rule;
+let borderBottomRightRadius: length => rule;
 
 let tableLayout: [ | `auto | `fixed] => rule;
 let borderCollapse: [ | `separate | `collapse] => rule;
 let borderSpacing: length => rule;
 
-let boxShadow : (~x:length=?, ~y:length=?, ~blur:length=?, ~spread:length=?, ~inset:bool=?, color) => [> | `shadow(string)];
-let boxShadows : list([ | `shadow(string)]) => rule;
+let boxShadow:
+  (
+    ~x: length=?,
+    ~y: length=?,
+    ~blur: length=?,
+    ~spread: length=?,
+    ~inset: bool=?,
+    color
+  ) =>
+  [> | `shadow(string)];
+let boxShadows: list([ | `shadow(string)]) => rule;
 
-let background : [ | color | `url(string) | gradient | `none] => rule;
-let backgroundColor: [ | color] => rule;
+let background: [ color | `url(string) | gradient | `none] => rule;
+let backgroundColor: [ color] => rule;
 let backgroundImage: [ | `url(string) | gradient | `none] => rule;
 let backgroundAttachment: [ | `scroll | `fixed | `local] => rule;
 let backgroundClip: [ | `borderBox | `contentBox | `paddingBox] => rule;
 let backgroundOrigin: [ | `borderBox | `contentBox | `paddingBox] => rule;
-let backgroundPosition: ([ | length], [ | length]) => rule;
+let backgroundPosition: ([ length], [ length]) => rule;
 let backgroundRepeat: [ | `repeat | `noRepeat | `repeatX | `repeatY] => rule;
-let backgroundSize: [ | `size(length, length) | `auto | `cover | `contain] => rule;
+let backgroundSize:
+  [ | `size(length, length) | `auto | `cover | `contain] => rule;
 
-let cursor : [
-  | `pointer
-  | `alias
-  | `allScroll
-  | `auto
-  | `cell
-  | `contextMenu
-  | `default
-  | `none
-  | `crosshair
-  | `copy
-  | `grab
-  | `grabbing
-  | `help
-  | `move
-  | `notAllowed
-  | `progress
-  | `text
-  | `wait
-  | `zoomIn
-  | `zoomOut
-  ] => rule;
-
-let clipPath : [
-  |`url(string)
+let cursor:
+  [
+    | `pointer
+    | `alias
+    | `allScroll
+    | `auto
+    | `cell
+    | `contextMenu
+    | `default
+    | `none
+    | `crosshair
+    | `copy
+    | `grab
+    | `grabbing
+    | `help
+    | `move
+    | `notAllowed
+    | `progress
+    | `text
+    | `wait
+    | `zoomIn
+    | `zoomOut
   ] =>
   rule;
 
+let clipPath: [ | `url(string)] => rule;
+
 type listStyleType = [
- | `disc
- | `circle
- | `square
- | `decimal
- | `lowerAlpha
- | `upperAlpha
- | `lowerGreek
- | `lowerLatin
- | `upperLatin
- | `lowerRoman
- | `upperRoman
- | `none
+  | `disc
+  | `circle
+  | `square
+  | `decimal
+  | `lowerAlpha
+  | `upperAlpha
+  | `lowerGreek
+  | `lowerLatin
+  | `upperLatin
+  | `lowerRoman
+  | `upperRoman
+  | `none
 ];
-let listStyle : (listStyleType, [ | `inside | `outside], [ | `none | `url(string)]) => rule;
-let listStyleType : listStyleType => rule;
-let listStylePosition : [ | `inside | `outside] => rule;
-let listStyleImage : [ | `none | `url(string)] => rule;
+let listStyle:
+  (listStyleType, [ | `inside | `outside], [ | `none | `url(string)]) => rule;
+let listStyleType: listStyleType => rule;
+let listStylePosition: [ | `inside | `outside] => rule;
+let listStyleImage: [ | `none | `url(string)] => rule;
 
-
-let opacity : float => rule;
+let opacity: float => rule;
 
 type outlineStyle = [
   | `none
@@ -591,83 +653,100 @@ type outlineStyle = [
   | `inset
   | `outset
 ];
-let outline : (length, outlineStyle, color) => rule;
-let outlineStyle : outlineStyle => rule;
-let outlineWidth : length => rule;
-let outlineColor : color => rule;
-let outlineOffset : length => rule;
+let outline: (length, outlineStyle, color) => rule;
+let outlineStyle: outlineStyle => rule;
+let outlineWidth: length => rule;
+let outlineColor: color => rule;
+let outlineOffset: length => rule;
 
-let pointerEvents : [ |`auto | `none] => rule;
-
+let pointerEvents: [ | `auto | `none] => rule;
 
 /**
  * Text
  */
 
-type fontStyle = [ | `italic | `normal | `oblique ];
+type fontStyle = [ | `italic | `normal | `oblique];
 
-let color : color => rule;
-let fontFamily : string => rule;
-let fontFace :
-  (~fontFamily: string, ~src: list([< `localUrl(string) | `url(string) ]),
-  ~fontStyle: fontStyle=?, ~fontWeight: int=?, unit) => string;
-let fontSize : length => rule;
-let fontVariant : [ | `normal | `smallCaps] => rule;
+let color: color => rule;
+let fontFamily: string => rule;
+let fontFace:
+  (
+    ~fontFamily: string,
+    ~src: list([< | `localUrl(string) | `url(string)]),
+    ~fontStyle: fontStyle=?,
+    ~fontWeight: int=?,
+    unit
+  ) =>
+  string;
+let fontSize: length => rule;
+let fontVariant: [ | `normal | `smallCaps] => rule;
 let fontStyle: fontStyle => rule;
-let fontWeight : int => rule;
-let letterSpacing: [ `normal | length] => rule;
+let fontWeight: int => rule;
+let letterSpacing: [ | `normal | length] => rule;
 let lineHeight: float => rule;
-let textAlign : [ | `left | `center | `right | `justify] => rule;
-let textDecoration : [ | `none | `underline | `overline | `lineThrough ] => rule;
-let textDecorationColor : color => rule;
-let textDecorationStyle : [ | `wavy | `solid | `dotted | `dashed | `double] => rule;
-let textIndent : length => rule;
-let textOverflow : [ | `clip | `ellipsis | `string(string)] => rule;
-let textShadow : (~x:length=?, ~y:length=?, ~blur:length=?, color) => rule;
+let textAlign: [ | `left | `center | `right | `justify] => rule;
+let textDecoration: [ | `none | `underline | `overline | `lineThrough] => rule;
+let textDecorationColor: color => rule;
+let textDecorationStyle:
+  [ | `wavy | `solid | `dotted | `dashed | `double] => rule;
+let textIndent: length => rule;
+let textOverflow: [ | `clip | `ellipsis | `string(string)] => rule;
+let textShadow: (~x: length=?, ~y: length=?, ~blur: length=?, color) => rule;
 let textTransform: [ | `uppercase | `lowercase | `capitalize | `none] => rule;
 let userSelect: [ | `auto | `all | `text | `none] => rule;
-let verticalAlign: [ | `baseline | length | `sub | `super | `top | `textTop | `middle | `bottom | `textBottom] => rule;
-let whiteSpace : [ | `normal | `nowrap | `pre | `preLine | `preWrap] => rule;
-let wordBreak : [ | `breakAll | `keepAll | `normal] => rule;
-let wordSpacing : [ | `normal | length ] => rule;
-let wordWrap : [ |`normal | `breakWord] => rule;
-
+let verticalAlign:
+  [
+    | `baseline
+    | length
+    | `sub
+    | `super
+    | `top
+    | `textTop
+    | `middle
+    | `bottom
+    | `textBottom
+  ] =>
+  rule;
+let whiteSpace: [ | `normal | `nowrap | `pre | `preLine | `preWrap] => rule;
+let wordBreak: [ | `breakAll | `keepAll | `normal] => rule;
+let wordSpacing: [ | `normal | length] => rule;
+let wordWrap: [ | `normal | `breakWord] => rule;
 
 /**
  * Transform
  */
 
 type transform = [
-   | `translate(length, length)
-   | `translate3d(length, length, length)
-   | `translateX(length)
-   | `translateY(length)
-   | `translateZ(length)
-   | `scale(float, float)
-   | `scale3d(float, float, float)
-   | `scaleX(float)
-   | `scaleY(float)
-   | `scaleZ(float)
-   | `rotate(angle)
-   | `rotate3d(float, float, float, angle)
-   | `rotateX(angle)
-   | `rotateY(angle)
-   | `rotateZ(angle)
-   | `skew(angle, angle)
-   | `skewX(angle)
-   | `skewY(angle)
-   | `perspective(int)
+  | `translate(length, length)
+  | `translate3d(length, length, length)
+  | `translateX(length)
+  | `translateY(length)
+  | `translateZ(length)
+  | `scale(float, float)
+  | `scale3d(float, float, float)
+  | `scaleX(float)
+  | `scaleY(float)
+  | `scaleZ(float)
+  | `rotate(angle)
+  | `rotate3d(float, float, float, angle)
+  | `rotateX(angle)
+  | `rotateY(angle)
+  | `rotateZ(angle)
+  | `skew(angle, angle)
+  | `skewX(angle)
+  | `skewY(angle)
+  | `perspective(int)
 ];
 
- let transform : transform => rule;
- let transforms : list(transform) => rule;
- let transformOrigin: (length, length) => rule;
- let transformOrigin3d: (length, length, length) => rule;
- let transformStyle: [ | `preserve3d | `flat] => rule;
- let perspective : [ `none | length] => rule;
- let perspectiveOrigin: (length, length) => rule;
+let transform: transform => rule;
+let transforms: list(transform) => rule;
+let transformOrigin: (length, length) => rule;
+let transformOrigin3d: (length, length, length) => rule;
+let transformStyle: [ | `preserve3d | `flat] => rule;
+let perspective: [ | `none | length] => rule;
+let perspectiveOrigin: (length, length) => rule;
 
- /**
+/**
   * Transition
   */
 type timingFunction = [
@@ -681,20 +760,26 @@ type timingFunction = [
   | `steps(int, [ | `start | `end_])
   | `cubicBezier(float, float, float, float)
 ];
-let transition : (~duration:int=?, ~delay:int=?, ~timingFunction:timingFunction=?, string) => [> |`transition(string)];
-let transitions : list([ | `transition(string)])=> rule;
-let transitionDelay : int => rule;
-let transitionDuration : int => rule;
-let transitionTimingFunction : timingFunction => rule;
-let transitionProperty : string => rule;
-
+let transition:
+  (
+    ~duration: int=?,
+    ~delay: int=?,
+    ~timingFunction: timingFunction=?,
+    string
+  ) =>
+  [> | `transition(string)];
+let transitions: list([ | `transition(string)]) => rule;
+let transitionDelay: int => rule;
+let transitionDuration: int => rule;
+let transitionTimingFunction: timingFunction => rule;
+let transitionProperty: string => rule;
 
 /**
  * Animation
  */
 
 type animation;
-let keyframes : list((int, list(rule))) => animation;
+let keyframes: list((int, list(rule))) => animation;
 
 type animationDirection = [
   | `normal
@@ -703,36 +788,37 @@ type animationDirection = [
   | `alternateReverse
 ];
 
-type animationFillMode = [ | `none | `forwards | `backwards | `both ];
-type animationIterationCount = [ | `infinite | `count(int) ];
-type animationPlayState = [ | `paused | `running ];
+type animationFillMode = [ | `none | `forwards | `backwards | `both];
+type animationIterationCount = [ | `infinite | `count(int)];
+type animationPlayState = [ | `paused | `running];
 
-let animation : (
-  ~duration:int=?,
-  ~delay:int=?,
-  ~direction:animationDirection=?,
-  ~timingFunction:timingFunction=?,
-  ~fillMode:animationFillMode=?,
-  ~playState:animationPlayState=?,
-  ~iterationCount:animationIterationCount=?,
-  animation
-  ) => [> | `animation(string)];
-let animations : list([ | `animation(string)]) => rule;
+let animation:
+  (
+    ~duration: int=?,
+    ~delay: int=?,
+    ~direction: animationDirection=?,
+    ~timingFunction: timingFunction=?,
+    ~fillMode: animationFillMode=?,
+    ~playState: animationPlayState=?,
+    ~iterationCount: animationIterationCount=?,
+    animation
+  ) =>
+  [> | `animation(string)];
+let animations: list([ | `animation(string)]) => rule;
 
-let animationDelay : int => rule;
-let animationDirection : animationDirection => rule;
-let animationDuration : int => rule;
-let animationFillMode : animationFillMode => rule;
+let animationDelay: int => rule;
+let animationDirection: animationDirection => rule;
+let animationDuration: int => rule;
+let animationFillMode: animationFillMode => rule;
 let animationIterationCount: [ | `infinite | `count(int)] => rule;
-let animationName : animation => rule;
-let animationPlayState : [ | `paused | `running] => rule;
-let animationTimingFunction : timingFunction => rule;
-
+let animationName: animation => rule;
+let animationPlayState: [ | `paused | `running] => rule;
+let animationTimingFunction: timingFunction => rule;
 
 /**
  * selectors
  */
-let selector : (string, list(rule)) => rule;
+let selector: (string, list(rule)) => rule;
 let active: list(rule) => rule;
 let after: list(rule) => rule;
 let before: list(rule) => rule;
@@ -771,11 +857,11 @@ let media: (string, list(rule)) => rule;
 
 module SVG: {
   let fill: color => rule;
-  let fillRule: [ `nonzero | `evenodd ] => rule;
+  let fillRule: [ | `nonzero | `evenodd] => rule;
   let fillOpacity: float => rule;
   let stroke: color => rule;
-  let strokeLinecap: [ `butt | `round | `square] => rule;
-  let strokeLinejoin: [ `miter | `round | `bevel] => rule;
+  let strokeLinecap: [ | `butt | `round | `square] => rule;
+  let strokeLinejoin: [ | `miter | `round | `bevel] => rule;
   let strokeMiterlimit: float => rule;
   let strokeWidth: length => rule;
   let strokeOpacity: float => rule;

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -31,6 +31,7 @@ type color = [
   | `hsla(int, int, int, float)
   | `transparent
   | `hex(string)
+  | `colorVariable(string)
   | `currentColor
 ];
 
@@ -224,6 +225,7 @@ type length = [
   | `vmin(float)
   | `vmax(float)
   | `vw(float)
+  | `lengthVariable(string)
   | `zero
 ];
 
@@ -868,3 +870,9 @@ module SVG: {
   let stopColor: color => rule;
   let stopOpacity: float => rule;
 };
+
+/**
+ * CSS Variables
+ */
+
+let setCssVariable: (~name: string, [ color | length]) => rule;

--- a/yarn.lock
+++ b/yarn.lock
@@ -481,9 +481,9 @@ bs-jest@^0.1.0:
   dependencies:
     jest "^19.0.2"
 
-bs-platform@3:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.0.0.tgz#38f200730db52fdea37819376b6ac3dfb20244c0"
+bs-platform@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.1.5.tgz#fb34ee4702bc9163848d5537096c4f31ebaeed40"
 
 bser@1.0.2:
   version "1.0.2"
@@ -2597,9 +2597,9 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-reason-react@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.3.4.tgz#afec4073ec0ea8122833f52b7e77219ef8ab8467"
+reason-react@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.4.2.tgz#690d34e3e91a2585cdc5f58384b6c8ff653c32c1"
   dependencies:
     react ">=15.0.0 || >=16.0.0"
     react-dom ">=15.0.0 || >=16.0.0"


### PR DESCRIPTION
First off, Thanks for this awesome library. I feel pretty passionate about helping out where I can here. I thought about creating an issue for this first, and I can definitely cross post there, but I wanted to get an example of what I think could work. There's probably a lot of work here or some things we shouldn't do. I am just getting started with Reason so I will be very gracious of any feedback on coding style, etc. 

Basically I am trying to currently build a theme system using css variables and i'd like to keep that really locked down inside of Reason by only supporting a set number of variables. I was planning on doing something like this in my code base:

```ocaml
type allowedColors =
  | Primary(Css.color)
  | Secondary(Css.color);

let setThemeColor = (variable) => {
  switch(variable) {
  | Primary(color) => Css.unsafe("--mdc-re-color-primary", string_of_color(color))
  | Secondary(color) => Css.unsafe("--mdc-re-color-secondary", string_of_color(color))
  };
};
```

to keep the variable names abstracted. The problem with doing this entirely in userland is that we don't have access to the helper methods inside the library for manipulating values. I had copy pasted them over but it seemed verbose and I was curious if something like this would make sense here.  