### PR TITLE
Moved bs-platform from "devDependencies" to "dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "url": "git+https://github.com/SentiaAnalytics/bs-css.git"
   },
   "dependencies": {
+    "bs-platform": "^3.1.5",
     "glamor": "^2.0.0"
   },
   "devDependencies": {
     "bs-jest": "^0.1.0",
-    "bs-platform": "^3.1.5",
     "reason-react": "^0.4.2",
     "webpack": "^3.8.1"
   },


### PR DESCRIPTION
The JavaScript packer I am using right now ([brunch.io](https://brunch.io/)) doesn't bother to include the bs-platform dependencies of bs-css (when bs-css is a dependency of my project) since bs-platform is listed as a "devDependency". I moved bs-platform to a regular "dependency", and now brunch is able to resolve the dependencies just fine. 