### PR TITLE
Add min-content and max-content support for gridLength

### DIFF
--- a/src/Css.re
+++ b/src/Css.re
@@ -663,7 +663,10 @@ let string_of_dimension = fun
   | `vmin(x) => string_of_float(x) ++ "vmin"
   | `vw(x) => string_of_float(x) ++ "vw"
   | `fr(x) => string_of_float(x) ++ "fr"
-  | `zero => "0";
+  | `zero => "0"
+  | `minContent => "min-content"
+  | `maxContent => "max-content";
+
 let width = x => d("width", string_of_dimension(x));
 let maxWidth = x => d("maxWidth", string_of_dimension(x));
 let minWidth = x => d("minWidth", string_of_dimension(x));

--- a/src/Css.re
+++ b/src/Css.re
@@ -343,7 +343,7 @@ type length = [
 ];
 
 type gridLength = [
-  length | `fr(float)
+  length | `fr(float) | `minContent | `maxContent
 ];
 
 let rec string_of_length =

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -226,7 +226,7 @@ type length = [
   | `zero
 ];
 
-type gridLength = [ length | `fr(float) ];
+type gridLength = [ length | `fr(float) | `minContent | `maxContent ];
 
 let ch : float => [> | `ch(float)];
 let cm : float => [> | `cm(float)];


### PR DESCRIPTION
This is just a small pull request that adds support for `minContent` and `maxContent` to `gridTemplateColumns` and `gridTemplateRows`.

ie:

```re
module Styles {
  open Css;
  let main = style([
    gridTemplateColumns([auto, maxContent, minContent])
  ]);
}
```

Which would yield:

```css
grid-template-columns: auto max-content min-content;
```