### PR TITLE
Add comment about Theme module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ In your `bsconfig.json`, include `"bs-css"` in the `bs-dependencies`.
 ## Usage
 
 ```reason
-
-
 module Styles = {
   /*Open the Css module, so we can access the style properties below without prefixing them with Css.*/
   open Css;
@@ -27,6 +25,7 @@ module Styles = {
     alignItems(stretch),
     backgroundColor(white),
     boxShadow(~y=px(3), ~blur=px(5), rgba(0, 0, 0, 0.3)),
+    /* You can place all your theme styles in Theme.re and access as normal Reason module */
     padding(Theme.basePadding)
   ]);
 


### PR DESCRIPTION
It better explains where `Theme` module comes from. For someone learning Reason for the first time it can be difficult to understand if `Theme` is part of the `bs-css` or its user-provided module with the application theme. It potentially can fix a lot of frustration 🙂