### PR TITLE
Fix typo lineThough -> lineThrough

### DIFF
--- a/example/bundle.js
+++ b/example/bundle.js
@@ -6624,7 +6624,7 @@ var underline = /* underline */131142924;
 
 var overline = /* overline */-986651832;
 
-var lineThrough = /* lineThough */-512623793;
+var lineThrough = /* lineThrough */412155569;
 
 var clip = /* clip */-1044222256;
 

--- a/lib/js/src/Css.js
+++ b/lib/js/src/Css.js
@@ -3147,7 +3147,7 @@ var underline = /* underline */131142924;
 
 var overline = /* overline */-986651832;
 
-var lineThrough = /* lineThough */-512623793;
+var lineThrough = /* lineThrough */412155569;
 
 var clip = /* clip */-1044222256;
 

--- a/src/Css.re
+++ b/src/Css.re
@@ -548,7 +548,7 @@ let oblique = `oblique;
 
 let underline = `underline;
 let overline = `overline;
-let lineThrough = `lineThough;
+let lineThrough = `lineThrough;
 let clip = `clip;
 let ellipsis = `ellipsis;
 

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -352,7 +352,7 @@ let oblique: [> | `oblique];
 
 let underline: [> | `underline];
 let overline: [> | `overline];
-let lineThrough: [> | `lineThough];
+let lineThrough: [> | `lineThrough];
 
 let clip: [> | `clip];
 let ellipsis: [> | `ellipsis];


### PR DESCRIPTION
## Summary

1. Fix a typo

- ❌  `lineThough`
- ✅ `lineThrough`

Used in [`text-decoration`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)