### PR TITLE
Swap emotion in for glamor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 statically typed DSL for writing css in reason.
 
-Bs-css is a statically typed interface to [Glamor](https://github.com/threepointone/glamor)
+Bs-css is a statically typed interface to [Emotion](https://github.com/emotion-js/emotion)
 
 ## Installation
 
@@ -18,10 +18,10 @@ In your `bsconfig.json`, include `"bs-css"` in the `bs-dependencies`.
 module Styles = {
   /*Open the Css module, so we can access the style properties below without prefixing them with Css.*/
   open Css;
-  
+
   let card = style([
     display(flexBox),
-    flexDirection(column), 
+    flexDirection(column),
     alignItems(stretch),
     backgroundColor(white),
     boxShadow(~y=px(3), ~blur=px(5), rgba(0, 0, 0, 0.3)),
@@ -100,6 +100,6 @@ Its on its way!
 until then you can check out [css.rei](./src/Css.rei).
 
 ## Thanks
-Thanks to [glamor](https://github.com/threepointone/glamor) which is doing all the heavi lifting.
+Thanks to [emotion](https://github.com/emotion-js/emotion) which is doing all the heavy lifting.
 Thanks to [bs-glamor](https://github.com/poeschko/bs-glamor) which this repo was forked from.
 Thanks to [elm-css](https://github.com/rtfeldman/elm-css) for dsl design inspiration.

--- a/example/test.re
+++ b/example/test.re
@@ -10,6 +10,7 @@ let arialNarrow =
       ~fontFamily="Arial FontFace Test",
       ~src=[localUrl("Arial Narrow")],
       ~fontStyle=normal,
+      ~fontWeight=500,
       (),
     )
   );

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "bs-css",
-  "version": "7.5.0",
-  "description": "BuckleScript bindings for glamor",
+  "version": "8.0.0",
+  "description": "BuckleScript bindings for emotion",
   "scripts": {
     "build": "bsb -make-world",
     "webpack": "webpack -w",
     "start": "bsb -make-world -w"
   },
   "keywords": [
-    "glamor",
+    "emotion",
     "bucklescript",
     "reason",
     "css"
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/SentiaAnalytics/bs-css.git"
   },
   "dependencies": {
-    "glamor": "^2.0.0"
+    "emotion": "^9.2.12"
   },
   "devDependencies": {
     "bs-platform": "^4.0.4",


### PR DESCRIPTION
This replacement for #92 (and #91) should hopefully be a little easier to read.

@giraud I don't believe there's a need for a migration doc as there's nothing to migrate API wise. Glamor's internal types didn't leak out of the interface previously (at least to my knowledge).

Would it make sense in the future to remove compiled assets from the repo? Especially if bsb has to generate them on the consuming side?

@baldurh thank you very much for trying to carry me through the process. This is the biggest PR I've attempted in public.
