### PR TITLE
Add methods for merging styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,47 @@ module Styles = {
 </div>
 ```
 
+## Merging styles
+
+You should avoid trying to merge styles in the same list of rules or by concatinating lists. A list of rules is converted into a JS object before being passed to Emotion where every property becomes a key in the object. This means you lose any earlier rule if you have another rule with the same property later in the list. This is especially noticable [when writing sub-selectors and media queries](https://github.com/SentiaAnalytics/bs-css/issues/86)
+
+`bs-css` offers two options for merging styles:
+
+1. `mergeStyles` merges styles by name. Uses [Emotion’s `cx` method](https://emotion.sh/docs/cx).
+   Rules will overrride earlier rules in the list.
+
+```reason
+let mergedStyles =
+  Css.(
+    mergeStyles([
+      style([padding(px(0))]),
+      style([fontSize(px(1))]),
+      style([padding(px(20)), fontSize(px(24)), color(blue)]),
+      style([media("(max-width: 768px)", [padding(px(10))])]),
+      style([
+        media("(max-width: 768px)", [fontSize(px(16)), color(red)]),
+      ]),
+    ])
+  );
+```
+
+2. `styleList` takes a list of rule lists (`list(list(rule))`) and passes an array of JS objects to [Emotion’s primary `css` method](https://emotion.sh/docs/object-styles#arrays)
+   effectively combining the rules. Rules will overrride earlier rules in the list.
+
+```reason
+let combinedStyles =
+  Css.(
+    styleList([
+      [padding(px(0)), fontSize(px(1))],
+      [padding(px(20)), fontSize(px(24)), color(blue)],
+      [media("(max-width: 768px)", [padding(px(10))])],
+      [media("(max-width: 768px)", [fontSize(px(16)), color(red)])],
+    ])
+  );
+```
+
+Both these methods should produce the same results.
+
 **Global css**
 
  You can define global css rules with `global`

--- a/example/test.re
+++ b/example/test.re
@@ -51,24 +51,13 @@ let miniBox =
 /* https://github.com/SentiaAnalytics/bs-css/issues/86 */
 let mergedStyles =
   Css.(
-    mergeStyles([
-      style([padding(px(0))]),
-      style([fontSize(px(1))]),
+    merge([
+      style([padding(px(0)), fontSize(px(1))]),
       style([padding(px(20)), fontSize(px(24)), color(blue)]),
       style([media("(max-width: 768px)", [padding(px(10))])]),
       style([
         media("(max-width: 768px)", [fontSize(px(16)), color(red)]),
       ]),
-    ])
-  );
-
-let combinedStyles =
-  Css.(
-    styleList([
-      [padding(px(0)), fontSize(px(1))],
-      [padding(px(20)), fontSize(px(24)), color(blue)],
-      [media("(max-width: 768px)", [padding(px(10))])],
-      [media("(max-width: 768px)", [fontSize(px(16)), color(red)])],
     ])
   );
 
@@ -1169,8 +1158,5 @@ let tests =
     </Section>
     <Section name="merging style names">
       <button className=mergedStyles> {text("Merged")} </button>
-    </Section>
-    <Section name="combining lists of styles">
-      <button className=combinedStyles> {text("Combined")} </button>
     </Section>
   </div>;

--- a/example/test.re
+++ b/example/test.re
@@ -48,6 +48,30 @@ let miniBox =
     margin(px(1)),
   ];
 
+/* https://github.com/SentiaAnalytics/bs-css/issues/86 */
+let mergedStyles =
+  Css.(
+    mergeStyles([
+      style([padding(px(0))]),
+      style([fontSize(px(1))]),
+      style([padding(px(20)), fontSize(px(24)), color(blue)]),
+      style([media("(max-width: 768px)", [padding(px(10))])]),
+      style([
+        media("(max-width: 768px)", [fontSize(px(16)), color(red)]),
+      ]),
+    ])
+  );
+
+let combinedStyles =
+  Css.(
+    styleList([
+      [padding(px(0)), fontSize(px(1))],
+      [padding(px(20)), fontSize(px(24)), color(blue)],
+      [media("(max-width: 768px)", [padding(px(10))])],
+      [media("(max-width: 768px)", [fontSize(px(16)), color(red)])],
+    ])
+  );
+
 let rowLayout = Css.[display(flexBox), flexDirection(row), flexWrap(wrap)];
 
 let section =
@@ -1142,5 +1166,11 @@ let tests =
     </Section>
     <Section name="insertRule, the ultimate escape hatch">
       <div className="raw-css" />
+    </Section>
+    <Section name="merging style names">
+      <button className=mergedStyles> {text("Merged")} </button>
+    </Section>
+    <Section name="combining lists of styles">
+      <button className=combinedStyles> {text("Combined")} </button>
     </Section>
   </div>;

--- a/src/Css.re
+++ b/src/Css.re
@@ -3,14 +3,15 @@ include Css_Colors;
 module Emotion = {
   type css = string;
   [@bs.module "emotion"] external _make: Js.Json.t => css = "css";
+  [@bs.module "emotion"] external _makeArray: array(Js.Json.t) => css = "css";
   [@bs.module "emotion"] external injectGlobal: Js.Json.t => unit = "";
   [@bs.module "emotion"]
   external rawInjectGlobal: string => unit = "injectGlobal";
   [@bs.module "emotion"]
   external makeKeyFrames: Js.Dict.t(Js.Json.t) => string = "keyframes";
-  [@bs.module "emotion"] [@bs.splice]
-  external merge: array(css) => css = "cx";
-  let merge: list(css) => css = classes => classes->Array.of_list->merge;
+  [@bs.module "emotion"] external cx: array(css) => css = "cx";
+  let mergeStyles: list(css) => css = classes => classes->Array.of_list->cx;
+
   let rec makeDict = ruleset => {
     let toJs = rule =>
       switch (rule) {
@@ -27,6 +28,8 @@ module Emotion = {
     ruleset |> List.map(toJs) |> Js.Dict.fromList |> Js.Json.object_;
   };
   let make = rules => rules |> makeDict |> _make;
+  let makeList = rulelist =>
+    rulelist |> List.map(makeDict) |> Array.of_list |> _makeArray;
 };
 
 let join = (separator, strings) => {
@@ -290,6 +293,7 @@ type selector = [ | `selector(string, list(rule))];
 let empty = [];
 
 let merge = List.concat;
+let mergeStyles = Emotion.mergeStyles;
 let global = (selector, rules: list(rule)) =>
   Emotion.injectGlobal(
     [(selector, Emotion.makeDict(rules))]
@@ -309,7 +313,8 @@ let keyframes = frames => {
   Emotion.makeKeyFrames @@ List.fold_left(addStop, Js.Dict.empty(), frames);
 };
 
-let style = rules => rules |> Emotion.make;
+let style = Emotion.make;
+let styleList = Emotion.makeList;
 
 let d = (property, value) => `declaration((property, value));
 

--- a/src/Css.re
+++ b/src/Css.re
@@ -1,16 +1,16 @@
 include Css_Colors;
 
 module Emotion = {
-  type css = string;
-  [@bs.module "emotion"] external _make: Js.Json.t => css = "css";
-  [@bs.module "emotion"] external _makeArray: array(Js.Json.t) => css = "css";
+  type stylename = string;
+  [@bs.module "emotion"] external _make: Js.Json.t => stylename = "css";
   [@bs.module "emotion"] external injectGlobal: Js.Json.t => unit = "";
   [@bs.module "emotion"]
   external rawInjectGlobal: string => unit = "injectGlobal";
   [@bs.module "emotion"]
   external makeKeyFrames: Js.Dict.t(Js.Json.t) => string = "keyframes";
-  [@bs.module "emotion"] external cx: array(css) => css = "cx";
-  let mergeStyles: list(css) => css = classes => classes->Array.of_list->cx;
+  [@bs.module "emotion"] external cx: array(stylename) => stylename = "cx";
+  let mergeStyles: list(stylename) => stylename =
+    stylenames => stylenames |> Array.of_list |> cx;
 
   let rec makeDict = ruleset => {
     let toJs = rule =>
@@ -28,8 +28,6 @@ module Emotion = {
     ruleset |> List.map(toJs) |> Js.Dict.fromList |> Js.Json.object_;
   };
   let make = rules => rules |> makeDict |> _make;
-  let makeList = rulelist =>
-    rulelist |> List.map(makeDict) |> Array.of_list |> _makeArray;
 };
 
 let join = (separator, strings) => {
@@ -292,8 +290,7 @@ type rule = [
 type selector = [ | `selector(string, list(rule))];
 let empty = [];
 
-let merge = List.concat;
-let mergeStyles = Emotion.mergeStyles;
+let merge = Emotion.mergeStyles;
 let global = (selector, rules: list(rule)) =>
   Emotion.injectGlobal(
     [(selector, Emotion.makeDict(rules))]
@@ -314,7 +311,6 @@ let keyframes = frames => {
 };
 
 let style = Emotion.make;
-let styleList = Emotion.makeList;
 
 let d = (property, value) => `declaration((property, value));
 

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -8,7 +8,9 @@ type rule = [
 
 let empty: list(rule);
 let merge: list(list(rule)) => list(rule);
+let mergeStyles: list(string) => string;
 let style: list(rule) => string;
+let styleList: list(list(rule)) => string;
 
 let global: (string, list(rule)) => unit;
 let insertRule: string => unit;

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -7,10 +7,8 @@ type rule = [
 ];
 
 let empty: list(rule);
-let merge: list(list(rule)) => list(rule);
-let mergeStyles: list(string) => string;
+let merge: list(string) => string;
 let style: list(rule) => string;
-let styleList: list(list(rule)) => string;
 
 let global: (string, list(rule)) => unit;
 let insertRule: string => unit;


### PR DESCRIPTION
Fixes #86 
Adds two new methods: `mergeStyles` and `styleList`
`mergeStyles` takes a list of style names and merges the styles by passing it on to Emotions `cx` method.
`styleList` takes a list of rule lists and (`list(list(rule))`) and passes each list through `makeDict` before passing it to Emotion. So it behaves pretty much just like `style` but for multiple lists of rules.

Adds a section in the README on best practices for merging styles and two examples.

I decided to not break `merge` in this first pass. But I’m definitely up for it if that is what the maintainers want.