### PR TITLE
`nthChild`

### DIFF
--- a/src/Css.re
+++ b/src/Css.re
@@ -1360,7 +1360,9 @@ let outlineOffset = x => d("outlineOffset", string_of_length(x));
  * Text
  */
 
-/* see https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Common_weight_name_mapping */
+/**
+ * see https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Common_weight_name_mapping
+ */
 type fontWeight = [
   | `num(int)
   | `thin
@@ -2003,9 +2005,8 @@ let animationTimingFunction = x =>
  * Selectors
  */
 
-let selector = (selector, rules) => `selector((selector, rules));
-
-/* MEDIA */
+let selector = (selector: string, rules: list(rule)) =>
+  `selector((selector, rules));
 
 let active = selector(":active");
 let after = selector("::after");
@@ -2026,6 +2027,8 @@ let required = selector(":required");
 let visited = selector(":visited");
 let enabled = selector(":enabled");
 let noContent = selector(":empty");
+let nthChild = (pattern, rules) =>
+  selector(":nth-child(" ++ pattern ++ ")", rules);
 let default = selector(":default");
 let anyLink = selector(":any-link");
 let onlyChild = selector(":only-child");
@@ -2039,6 +2042,8 @@ let firstLine = selector("::first-line");
 let firstLetter = selector("::first-letter");
 let selection = selector("::selection");
 let placeholder = selector("::placeholder");
+
+/* MEDIA */
 
 let media = (query, rules) => `selector(("@media " ++ query, rules));
 

--- a/src/Css.re
+++ b/src/Css.re
@@ -2004,7 +2004,6 @@ let animationTimingFunction = x =>
 /**
  * Selectors
  */
-
 let selector = (selector: string, rules: list(rule)) =>
   `selector((selector, rules));
 
@@ -2043,8 +2042,9 @@ let firstLetter = selector("::first-letter");
 let selection = selector("::selection");
 let placeholder = selector("::placeholder");
 
-/* MEDIA */
-
+/**
+ * Media
+ */
 let media = (query, rules) => `selector(("@media " ++ query, rules));
 
 /**

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -757,7 +757,9 @@ let pointerEvents: [ | `auto | `none] => rule;
  * Text
  */
 
-/* see https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Common_weight_name_mapping */
+/**
+ * see https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Common_weight_name_mapping
+ */
 type fontWeight = [
   | `num(int)
   | `thin
@@ -938,9 +940,10 @@ let animationPlayState: [ | `paused | `running] => rule;
 let animationTimingFunction: timingFunction => rule;
 
 /**
- * selectors
+ * Selectors
  */
 let selector: (string, list(rule)) => rule;
+
 let active: list(rule) => rule;
 let after: list(rule) => rule;
 let before: list(rule) => rule;
@@ -960,6 +963,7 @@ let required: list(rule) => rule;
 let visited: list(rule) => rule;
 let enabled: list(rule) => rule;
 let noContent: list(rule) => rule;
+let nthChild: (string, list(rule)) => rule;
 let default: list(rule) => rule;
 let anyLink: list(rule) => rule;
 let onlyChild: list(rule) => rule;
@@ -974,12 +978,14 @@ let firstLetter: list(rule) => rule;
 let selection: list(rule) => rule;
 let placeholder: list(rule) => rule;
 
+/**
+ * Media
+ */
 let media: (string, list(rule)) => rule;
 
 /**
  * SVG
  */
-
 module SVG: {
   let fill: color => rule;
   let fillRule: [ | `nonzero | `evenodd] => rule;


### PR DESCRIPTION
Implements #116 

It's not as guarded as it could be as I'm just accepting a string for the `nth-child(pattern)` argument. If someone would like to direct me how to better guard it with the accepted patterns, you can find the docs for `nth-child` [here](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child).