### PR TITLE
Change flexShrink type to float to match flexGrow type; fixes #109

### DIFF
--- a/example/Test.re
+++ b/example/Test.re
@@ -562,7 +562,7 @@ let tests =
             className=Css.(
               style(
                 box
-                @ [order(1), flexGrow(1.), flexShrink(1), flexBasis(auto)],
+                @ [order(1), flexGrow(1.), flexShrink(1.0), flexBasis(auto)],
               )
             )
           />

--- a/src/Css.re
+++ b/src/Css.re
@@ -712,7 +712,7 @@ let right = x => d("right", string_of_length(x));
 
 let flex = x => d("flex", string_of_int(x));
 let flexGrow = x => d("flexGrow", string_of_float(x));
-let flexShrink = x => d("flexShrink", string_of_int(x));
+let flexShrink = x => d("flexShrink", string_of_float(x));
 let flexBasis = x =>
   d(
     "flexBasis",

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -496,7 +496,7 @@ let right: length => rule;
 
 let flex: int => rule;
 let flexGrow: float => rule;
-let flexShrink: int => rule;
+let flexShrink: float => rule;
 let flexBasis:
   [
     length


### PR DESCRIPTION
An earlier PR (#106 ) was merged that changed `flexGrow` type from `int` to `float`. This commit matches that change for `flexShrink`.

This fixes issue #109 .