### PR TITLE
Add support for `length` values in gradient color stops

### DIFF
--- a/__tests__/Css_test.re
+++ b/__tests__/Css_test.re
@@ -117,3 +117,23 @@ describe("Direction", () =>
        ))
   )
 );
+
+describe("Gradient background", () =>
+  test("test values", () =>
+    expect(
+      (
+        r(background(linearGradient(deg(45.), [(zero, red), (pct(100.), blue)]))),
+        r(background(repeatingLinearGradient(deg(45.), [(zero, red), (px(10), blue)]))),
+        r(background(radialGradient([(zero, red), (pct(100.), blue)]))),
+        r(background(repeatingRadialGradient([(zero, red), (Calc.(pct(20.) + px(5)), blue)]))),
+      )
+      ->Js.Json.stringifyAny,
+    )
+    |> toBeJson((
+         {"background": "linear-gradient(45deg, #FF0000 0, #0000FF 100%)"},
+         {"background": "repeating-linear-gradient(45deg, #FF0000 0, #0000FF 10px)"},
+         {"background": "radial-gradient(#FF0000 0, #0000FF 100%)"},
+         {"background": "repeating-radial-gradient(#FF0000 0, #0000FF calc(20% + 5px))"},
+       ))
+  )
+);

--- a/example/Test.re
+++ b/example/Test.re
@@ -278,7 +278,7 @@ let tests =
             box
             @ [
               background(
-                linearGradient(deg(45.), [(0, red), (100, blue)]),
+                linearGradient(deg(45.), [(zero, red), (pct(100.), blue)]),
               ),
             ],
           )
@@ -290,7 +290,7 @@ let tests =
             box
             @ [
               background(
-                repeatingLinearGradient(deg(45.), [(0, red), (10, blue)]),
+                repeatingLinearGradient(deg(45.), [(zero, red), (pct(10.), blue)]),
               ),
             ],
           )
@@ -299,7 +299,7 @@ let tests =
       <div
         className=Css.(
           style(
-            box @ [background(radialGradient([(0, red), (100, blue)]))],
+            box @ [background(radialGradient([(zero, red), (pct(100.), blue)]))],
           )
         )
       />
@@ -308,7 +308,7 @@ let tests =
           style(
             box
             @ [
-              background(repeatingRadialGradient([(0, red), (10, blue)])),
+              background(repeatingRadialGradient([(zero, red), (pct(10.), blue)])),
             ],
           )
         )
@@ -788,7 +788,7 @@ let tests =
           style(
             box
             @ [
-              background(radialGradient([(0, red), (10, blue)])),
+              background(radialGradient([(zero, red), (pct(10.), blue)])),
               backgroundAttachment(fixed),
               backgroundClip(contentBox),
               backgroundOrigin(contentBox),
@@ -822,7 +822,7 @@ let tests =
               backgroundImage(
                 linearGradient(
                   deg(45.),
-                  [(0, green), (50, red), (100, yellow)],
+                  [(zero, green), (pct(50.), red), (pct(100.), yellow)],
                 ),
               ),
               backgroundRepeat(repeatY),

--- a/src/Css.re
+++ b/src/Css.re
@@ -63,6 +63,28 @@ let string_of_float = Js.Float.toString;
 let string_of_int = Js.Int.toString;
 
 module Converter = {
+  let rec string_of_length =
+    fun
+    | `calc(`add, a, b) =>
+      "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
+    | `calc(`sub, a, b) =>
+      "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
+    | `ch(x) => string_of_float(x) ++ "ch"
+    | `cm(x) => string_of_float(x) ++ "cm"
+    | `em(x) => string_of_float(x) ++ "em"
+    | `ex(x) => string_of_float(x) ++ "ex"
+    | `mm(x) => string_of_float(x) ++ "mm"
+    | `percent(x) => string_of_float(x) ++ "%"
+    | `pt(x) => string_of_int(x) ++ "pt"
+    | `px(x) => string_of_int(x) ++ "px"
+    | `pxFloat(x) => string_of_float(x) ++ "px"
+    | `rem(x) => string_of_float(x) ++ "rem"
+    | `vh(x) => string_of_float(x) ++ "vh"
+    | `vmax(x) => string_of_float(x) ++ "vmax"
+    | `vmin(x) => string_of_float(x) ++ "vmin"
+    | `vw(x) => string_of_float(x) ++ "vw"
+    | `zero => "0";
+
   let string_of_angle =
     fun
     | `deg(x) => string_of_float(x) ++ "deg"
@@ -123,8 +145,8 @@ module Converter = {
 
   let string_of_stops = stops =>
     stops
-    |> List.map(((i, c)) =>
-         join(" ", [string_of_color(c), string_of_int(i) ++ "%"])
+    |> List.map(((l, c)) =>
+         join(" ", [string_of_color(c), string_of_length(l)])
        )
     |> join(", ");
 
@@ -141,28 +163,6 @@ module Converter = {
     ++ ", "
     ++ string_of_stops(stops)
     ++ ")";
-
-  let rec string_of_length =
-    fun
-    | `calc(`add, a, b) =>
-      "calc(" ++ string_of_length(a) ++ " + " ++ string_of_length(b) ++ ")"
-    | `calc(`sub, a, b) =>
-      "calc(" ++ string_of_length(a) ++ " - " ++ string_of_length(b) ++ ")"
-    | `ch(x) => string_of_float(x) ++ "ch"
-    | `cm(x) => string_of_float(x) ++ "cm"
-    | `em(x) => string_of_float(x) ++ "em"
-    | `ex(x) => string_of_float(x) ++ "ex"
-    | `mm(x) => string_of_float(x) ++ "mm"
-    | `percent(x) => string_of_float(x) ++ "%"
-    | `pt(x) => string_of_int(x) ++ "pt"
-    | `px(x) => string_of_int(x) ++ "px"
-    | `pxFloat(x) => string_of_float(x) ++ "px"
-    | `rem(x) => string_of_float(x) ++ "rem"
-    | `vh(x) => string_of_float(x) ++ "vh"
-    | `vmax(x) => string_of_float(x) ++ "vmax"
-    | `vmin(x) => string_of_float(x) ++ "vmin"
-    | `vw(x) => string_of_float(x) ++ "vw"
-    | `zero => "0";
 
   let string_of_translate3d = (x, y, z) =>
     "translate3d("
@@ -407,6 +407,25 @@ let unset = `unset;
 let rtl = `rtl;
 let ltr = `ltr;
 
+type length = [
+  | `calc([ | `add | `sub], length, length)
+  | `ch(float)
+  | `cm(float)
+  | `em(float)
+  | `ex(float)
+  | `mm(float)
+  | `percent(float)
+  | `pt(int)
+  | `px(int)
+  | `pxFloat(float)
+  | `rem(float)
+  | `vh(float)
+  | `vmax(float)
+  | `vmin(float)
+  | `vw(float)
+  | `zero
+];
+
 type angle = [ | `deg(float) | `rad(float) | `grad(float) | `turn(float)];
 
 let deg = x => `deg(x);
@@ -433,10 +452,10 @@ let hex = x => `hex(x);
 let currentColor = `currentColor;
 
 type gradient = [
-  | `linearGradient(angle, list((int, color)))
-  | `repeatingLinearGradient(angle, list((int, color)))
-  | `radialGradient(list((int, color)))
-  | `repeatingRadialGradient(list((int, color)))
+  | `linearGradient(angle, list((length, color)))
+  | `repeatingLinearGradient(angle, list((length, color)))
+  | `radialGradient(list((length, color)))
+  | `repeatingRadialGradient(list((length, color)))
 ];
 
 let linearGradient = (angle, stops) => `linearGradient((angle, stops));
@@ -451,25 +470,6 @@ let repeatingRadialGradient = stops => `repeatingRadialGradient(stops);
 /**
  * Units
  */
-
-type length = [
-  | `calc([ | `add | `sub], length, length)
-  | `ch(float)
-  | `cm(float)
-  | `em(float)
-  | `ex(float)
-  | `mm(float)
-  | `percent(float)
-  | `pt(int)
-  | `px(int)
-  | `pxFloat(float)
-  | `rem(float)
-  | `vh(float)
-  | `vmax(float)
-  | `vmin(float)
-  | `vw(float)
-  | `zero
-];
 
 let string_of_length_cascading =
   fun

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -34,6 +34,25 @@ let unset: [> | `unset];
 let rtl: [> | `rtl];
 let ltr: [> | `ltr];
 
+type length = [
+  | `calc([ | `add | `sub], length, length)
+  | `ch(float)
+  | `cm(float)
+  | `em(float)
+  | `ex(float)
+  | `mm(float)
+  | `percent(float)
+  | `pt(int)
+  | `px(int)
+  | `pxFloat(float)
+  | `rem(float)
+  | `vh(float)
+  | `vmin(float)
+  | `vmax(float)
+  | `vw(float)
+  | `zero
+];
+
 type angle = [ | `deg(float) | `rad(float) | `grad(float) | `turn(float)];
 
 let deg: float => [> | `deg(float)];
@@ -60,22 +79,22 @@ let transparent: [> | `transparent];
 let currentColor: [> | `currentColor];
 
 type gradient = [
-  | `linearGradient(angle, list((int, color)))
-  | `repeatingLinearGradient(angle, list((int, color)))
-  | `radialGradient(list((int, color)))
-  | `repeatingRadialGradient(list((int, color)))
+  | `linearGradient(angle, list((length, color)))
+  | `repeatingLinearGradient(angle, list((length, color)))
+  | `radialGradient(list((length, color)))
+  | `repeatingRadialGradient(list((length, color)))
 ];
 
 let linearGradient:
-  (angle, list((int, color))) =>
-  [> | `linearGradient(angle, list((int, color)))];
+  (angle, list((length, color))) =>
+  [> | `linearGradient(angle, list((length, color)))];
 let repeatingLinearGradient:
-  (angle, list((int, color))) =>
-  [> | `repeatingLinearGradient(angle, list((int, color)))];
+  (angle, list((length, color))) =>
+  [> | `repeatingLinearGradient(angle, list((length, color)))];
 let radialGradient:
-  list((int, color)) => [> | `radialGradient(list((int, color)))];
+  list((length, color)) => [> | `radialGradient(list((length, color)))];
 let repeatingRadialGradient:
-  list((int, color)) => [> | `repeatingRadialGradient(list((int, color)))];
+  list((length, color)) => [> | `repeatingRadialGradient(list((length, color)))];
 
 let aliceblue: [> | `hex(string)];
 let antiquewhite: [> | `hex(string)];
@@ -225,25 +244,6 @@ let white: [> | `hex(string)];
 let whitesmoke: [> | `hex(string)];
 let yellow: [> | `hex(string)];
 let yellowgreen: [> | `hex(string)];
-
-type length = [
-  | `calc([ | `add | `sub], length, length)
-  | `ch(float)
-  | `cm(float)
-  | `em(float)
-  | `ex(float)
-  | `mm(float)
-  | `percent(float)
-  | `pt(int)
-  | `px(int)
-  | `pxFloat(float)
-  | `rem(float)
-  | `vh(float)
-  | `vmin(float)
-  | `vmax(float)
-  | `vw(float)
-  | `zero
-];
 
 type repeatValue = [ | `autoFill | `autoFit | `num(int)];
 type minmax = [ | `fr(float) | `minContent | `maxContent | `auto | length];


### PR DESCRIPTION
Related to #133
A color-stop's positions accept `<percentage>` or `<length>` types
https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Formal_syntax
