### PR TITLE
Update background-position definition

### DIFF
--- a/__tests__/Css_test.re
+++ b/__tests__/Css_test.re
@@ -535,6 +535,85 @@ describe("GridArea", () => {
   );
 });
 
+describe("backgroundPosition", () => {
+  test("test single values", () =>
+    expect(
+      (
+        r(backgroundPosition(`left)),
+        r(backgroundPosition(`right)),
+        r(backgroundPosition(`top)),
+        r(backgroundPosition(`bottom)),
+        r(backgroundPosition(center)),
+        r(backgroundPosition(pct(50.))),
+        r(backgroundPosition(initial)),
+        r(backgroundPosition(inherit_)),
+        r(backgroundPosition(unset)),
+      )
+      ->Js.Json.stringifyAny,
+    )
+    |> toBeJson((
+         {"backgroundPosition": "left"},
+         {"backgroundPosition": "right"},
+         {"backgroundPosition": "top"},
+         {"backgroundPosition": "bottom"},
+         {"backgroundPosition": "center"},
+         {"backgroundPosition": "50%"},
+         {"backgroundPosition": "initial"},
+         {"backgroundPosition": "inherit"},
+         {"backgroundPosition": "unset"},
+       ))
+  );
+
+  test("test two values", () =>
+    expect(
+      (
+        r(backgroundPosition(`hv(`left, center))),
+        r(backgroundPosition(`hv(`right, pct(50.)))),
+        r(backgroundPosition(`hv(pct(50.), `top))),
+        r(backgroundPosition(`hv(pct(50.), pct(50.)))),
+      )
+      ->Js.Json.stringifyAny,
+    )
+    |> toBeJson((
+         {"backgroundPosition": "left center"},
+         {"backgroundPosition": "right 50%"},
+         {"backgroundPosition": "50% top"},
+         {"backgroundPosition": "50% 50%"},
+       ))
+  );
+
+  test("test multiple positions", () =>
+    expect(
+      (
+        r(backgroundPositions([`hv(px(0), px(0)), center])),
+      )
+      ->Js.Json.stringifyAny,
+    )
+    |> toBeJson((
+         {"backgroundPosition": "0px 0px, center"},
+       ))
+  );
+
+  test("test edge offsets values", () =>
+    expect(
+      (
+        r(
+          backgroundPosition4(
+            ~y=`top,
+            ~offsetY=px(10),
+            ~x=`right,
+            ~offsetX=px(50),
+          ),
+        ),
+      )
+      ->Js.Json.stringifyAny,
+    )
+    |> toBeJson((
+         {"backgroundPosition": "right 50px top 10px"},
+       ))
+  );
+});
+
 describe("backgroundRepeat", () => {
   test("test single values", () =>
     expect(

--- a/example/Test.re
+++ b/example/Test.re
@@ -814,7 +814,7 @@ let make = () =>
               backgroundAttachment(scroll),
               backgroundClip(borderBox),
               backgroundOrigin(borderBox),
-              backgroundPosition(pct(50.), pct(50.)),
+              backgroundPosition(`hv(pct(50.), pct(50.))),
               backgroundRepeat(noRepeat),
               backgroundSize(size(px(100), px(100))),
             ],

--- a/src/Css.re
+++ b/src/Css.re
@@ -286,8 +286,43 @@ let backgroundOrigin = x =>
     },
   );
 
-let backgroundPosition = (x, y) =>
-  D("backgroundPosition", Length.toString(x) ++ " " ++ Length.toString(y));
+let string_of_backgroundposition =
+  fun
+  | #BackgroundPosition.t as bp => BackgroundPosition.toString(bp)
+  | `hv(h, v) =>
+    (
+      switch (h) {
+      | #BackgroundPosition.X.t as h => BackgroundPosition.X.toString(h)
+      | #Length.t as l => Length.toString(l)
+      }
+    )
+    ++ " "
+    ++ (
+      switch (v) {
+      | #BackgroundPosition.Y.t as v => BackgroundPosition.Y.toString(v)
+      | #Length.t as l => Length.toString(l)
+      }
+    )
+  | #Length.t as l => Length.toString(l)
+  | #Cascading.t as c => Cascading.toString(c);
+
+let backgroundPosition = x =>
+  D("backgroundPosition", string_of_backgroundposition(x));
+
+let backgroundPositions = bp =>
+  D("backgroundPosition", bp->Belt.List.map(string_of_backgroundposition)->join(", "));
+
+let backgroundPosition4 = (~x, ~offsetX, ~y, ~offsetY) =>
+  D(
+    "backgroundPosition",
+    BackgroundPosition.X.toString(x)
+    ++ " "
+    ++ Length.toString(offsetX)
+    ++ " "
+    ++ BackgroundPosition.Y.toString(y)
+    ++ " "
+    ++ Length.toString(offsetY),
+  );
 
 let backgroundRepeat = x =>
   D(

--- a/src/Css.rei
+++ b/src/Css.rei
@@ -173,7 +173,40 @@ let backgroundOrigin: [ Types.BackgroundClip.t | Types.Cascading.t] => rule;
  The background-position CSS property sets the initial position for each background image.
  The position is relative to the position layer set by background-origin.
  */
-let backgroundPosition: ([ Types.Length.t], [ Types.Length.t]) => rule;
+let backgroundPosition:
+  [
+    Types.BackgroundPosition.t
+    | `hv(
+        [ Types.BackgroundPosition.X.t | Types.Length.t],
+        [ Types.BackgroundPosition.Y.t | Types.Length.t]
+      )
+    | Types.Length.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+let backgroundPositions:
+  list(
+    [
+      Types.BackgroundPosition.t
+      | `hv(
+          [ Types.BackgroundPosition.X.t | Types.Length.t],
+          [ Types.BackgroundPosition.Y.t | Types.Length.t]
+        )
+      | Types.Length.t
+      | Types.Cascading.t
+    ]
+  ) =>
+  rule;
+
+let backgroundPosition4:
+  (
+    ~x: Types.BackgroundPosition.X.t,
+    ~offsetX: Types.Length.t,
+    ~y: Types.BackgroundPosition.Y.t,
+    ~offsetY: Types.Length.t
+  ) =>
+  rule;
 
 /**
  The background-repeat CSS property sets how background images are repeated.

--- a/src/Css_Types.re
+++ b/src/Css_Types.re
@@ -1231,6 +1231,38 @@ module BackgroundOrigin = {
     | `paddingBox => "padding-box";
 };
 
+module BackgroundPosition = {
+  module X {
+    type t = [ | `left | `right | `center];
+
+    let toString =
+      fun
+      | `left => "left"
+      | `right => "right"
+      | `center => "center";
+  };
+
+  module Y {
+    type t = [ | `top | `bottom | `center];
+
+    let toString =
+      fun
+      | `top => "top"
+      | `bottom => "bottom"
+      | `center => "center";
+  };
+
+  type t = [ | X.t | Y.t];
+
+  let toString =
+    fun
+    | `left => "left"
+    | `right => "right"
+    | `top => "top"
+    | `bottom => "bottom"
+    | `center => "center";
+};
+
 module BackgroundRepeat = {
   type twoValue = [ | `repeat | `space | `round | `noRepeat];
   type t = [ | `repeatX | `repeatY | twoValue];

--- a/src/Css_Types.rei
+++ b/src/Css_Types.rei
@@ -878,6 +878,27 @@ module BackgroundOrigin: {
 };
 
 /**
+ https://developer.mozilla.org/docs/Web/CSS/background-position
+ */
+module BackgroundPosition: {
+  module X {
+    type t = [ | `left | `right | `center];
+
+    let toString: t => string;
+  };
+
+  module Y {
+    type t = [ | `top | `bottom | `center];
+
+    let toString: t => string;
+  };
+
+  type t = [ | X.t | Y.t];
+
+  let toString: t => string;
+};
+
+/**
  https://developer.mozilla.org/docs/Web/CSS/background-origin
  */
 module BackgroundRepeat: {


### PR DESCRIPTION
I tried to update `backgroundPosition` so it can define a single value (keyword, length or percentage) or two values. This would be a breaking change though

Also, I added `backgroundPositions` for defining multiple positions and `backgroundPosition4` for defining edge offset values, with some tests. Perhaps they can serve the needs of common use cases