### PR TITLE
Extend rule to use gridLength type

### DIFF
--- a/src/Css.rei
+++ b/src/Css.rei
@@ -1418,8 +1418,6 @@ let flex3:
     ~basis: [ Types.Length.t | Types.FlexBasis.t]
   ) =>
   rule;
-let gridAutoColumns: [ Types.Length.t | `auto] => rule;
-let gridAutoRows: [ Types.Length.t | `auto] => rule;
 
 let border:
   (
@@ -1463,6 +1461,8 @@ type trackLength = [
 ];
 type gridLength = [ trackLength | `repeat(Types.RepeatValue.t, trackLength)];
 
+let gridAutoColumns: [ trackLength | `auto] => rule;
+let gridAutoRows: [ trackLength | `auto] => rule;
 let gridTemplateColumns: list([ gridLength | `auto]) => rule;
 let gridTemplateRows: list([ gridLength | `auto]) => rule;
 


### PR DESCRIPTION
Problem:
`gridAutoRows` does not support `flex` values, so as a developer I need to use a workaround such as: `unsafe("grid-auto-rows", "1fr")`

Scope of changes:
Extend `gridAutoColumns` and `gridAutoRows` rule to use `trackLength`

grid-auto-rows and grid-auto-columns specs:
https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-rows